### PR TITLE
Changed DEBUG log level to ROSDEBUG.

### DIFF
--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -411,7 +411,7 @@ namespace ros {
 
     public:
       void logdebug(const char* msg){
-        log(rosserial_msgs::Log::DEBUG, msg);
+        log(rosserial_msgs::Log::ROSDEBUG, msg);
       }
       void loginfo(const char * msg){
         log(rosserial_msgs::Log::INFO, msg);

--- a/rosserial_msgs/msg/Log.msg
+++ b/rosserial_msgs/msg/Log.msg
@@ -1,6 +1,6 @@
 
 #ROS Logging Levels
-uint8 DEBUG=0
+uint8 ROSDEBUG=0
 uint8 INFO=1
 uint8 WARN=2
 uint8 ERROR=3


### PR DESCRIPTION
Using DEBUG as a log level is problematic for developers, because DEBUG is frequently defined as a symbol when debugging projects. I suggest changing the log level to ROSDEBUG to avoid this namespace conflict.
