### PR TITLE
Added missing math.h include.

### DIFF
--- a/rosserial_client/src/ros_lib/ros/duration.h
+++ b/rosserial_client/src/ros_lib/ros/duration.h
@@ -35,6 +35,8 @@
 #ifndef _ROS_DURATION_H_
 #define _ROS_DURATION_H_
 
+#include <math.h>
+
 namespace ros {
 
   void normalizeSecNSecSigned(long& sec, long& nsec);


### PR DESCRIPTION
duration.h uses math functions like floor(), but doesn't explicitly include the math library, leading to compile errors.
