### PR TITLE
rosserial_embeddedlinux: Fix CMakeLists.txt ...

### DIFF
--- a/rosserial_embeddedlinux/CMakeLists.txt
+++ b/rosserial_embeddedlinux/CMakeLists.txt
@@ -8,7 +8,7 @@ install(DIRECTORY src/ros_lib
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/src
 )
 
-install(DIRECTORY examples
+install(DIRECTORY src/examples
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/src
 )
 


### PR DESCRIPTION
so 'catkin_make install' can find 'examples' directory under 'src' directory in rosserial_embeddedlinux

This is so that the following part of the Arduino IDE Setup of rosserial can run properly:
http://ros.org/wiki/rosserial_arduino/Tutorials/Arduino%20IDE%20Setup#Installing_from_Source_onto_the_ROS_workstation
