### PR TITLE
Groovy devel

### DIFF
--- a/rosserial_embeddedlinux/CMakeLists.txt
+++ b/rosserial_embeddedlinux/CMakeLists.txt
@@ -8,7 +8,7 @@ install(DIRECTORY src/ros_lib
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/src
 )
 
-install(DIRECTORY examples
+install(DIRECTORY src/examples
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/src
 )
 

--- a/rosserial_python/nodes/serial_node.py
+++ b/rosserial_python/nodes/serial_node.py
@@ -43,10 +43,12 @@ import sys
    
 if __name__=="__main__":
 
+    rospy.init_node("rosserial_node")
+    rospy.loginfo("ROS Serial Python Node")
     port_name = rospy.get_param('~port','/dev/ttyUSB0')
     baud = int(rospy.get_param('~baud','57600'))
     tcp_portnum = int(rospy.get_param('/rosserial_embeddedlinux/tcp_port', '11411'))
-    fork_server = rospy.get_param('/rosserial_embeddedlinux/fork_server', True)
+    fork_server = rospy.get_param('/rosserial_embeddedlinux/fork_server', False)
 
     sys.argv = rospy.myargv(argv=sys.argv)
     
@@ -71,8 +73,6 @@ if __name__=="__main__":
             rospy.loginfo("All done")
 
     else :          # Use serial port 
-        rospy.init_node("serial_node")
-        rospy.loginfo("ROS Serial Python Node")
         rospy.loginfo("Connecting to %s at %d baud" % (port_name,baud) )
         client = SerialClient(port_name, baud)
         try:

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -229,8 +229,6 @@ class RosSerialServer:
                 process.start()
                 rospy.loginfo("launched startSocketServer")
             else:
-                rospy.init_node("serial_node")
-                rospy.loginfo("ROS Serial Python Node")
                 rospy.loginfo("calling startSerialClient")
                 self.startSerialClient()
                 rospy.loginfo("startSerialClient() exited")


### PR DESCRIPTION
Fix broken private parameters, which got broken when rosserial_embeddedLinux was merged in. Fixes #43 but breaks fork_server aspect of rosserial_embeddedLinux. Set fork_server to default to False for now
