### PR TITLE
Hydro devel

### DIFF
--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -197,8 +197,8 @@ namespace ros {
               mode_++;
             }else{
               mode_ = MODE_FIRST_FF;
-	      if (configured_ == false)
-	         requestSyncTime(); 	/* send a msg back showing our protocol version */
+              if (configured_ == false)
+                  requestSyncTime(); 	/* send a msg back showing our protocol version */
             }
 	  }else if( mode_ == MODE_SIZE_L ){   /* bottom half of message size */
             bytes_ = data;

--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -43,7 +43,18 @@
 #define SYNC_SECONDS        5
 
 #define MODE_FIRST_FF       0
-#define MODE_SECOND_FF      1
+/*
+ * The second sync byte is a protocol version. It's value is 0xff for the first
+ * version of the rosserial protocol (used up to hydro), 0xfe for the second version
+ * (introduced in hydro), 0xfd for the next, and so on. Its purpose is to enable
+ * detection of mismatched protocol versions (e.g. hydro rosserial_python with groovy
+ * rosserial_arduino. It must be changed in both this file and in
+ * rosserial_python/src/rosserial_python/SerialClient.py
+ */
+#define MODE_PROTOCOL_VER   1
+#define PROTOCOL_VER1		0xff // through groovy
+#define PROTOCOL_VER2		0xfe // in hydro
+#define PROTOCOL_VER 		PROTOCOL_VER2
 #define MODE_SIZE_L         2   
 #define MODE_SIZE_H         3
 #define MODE_SIZE_CHECKSUM  4   // checksum for msg size received from size L and H
@@ -181,11 +192,13 @@ namespace ros {
               mode_++;
               last_msg_timeout_time = c_time + MSG_TIMEOUT;
             }
-          }else if( mode_ == MODE_SECOND_FF ){
-            if(data == 0xff){
+          }else if( mode_ == MODE_PROTOCOL_VER ){
+            if(data == PROTOCOL_VER){
               mode_++;
             }else{
               mode_ = MODE_FIRST_FF;
+	      if (configured_ == false)
+	         requestSyncTime(); 	/* send a msg back showing our protocol version */
             }
 	  }else if( mode_ == MODE_SIZE_L ){   /* bottom half of message size */
             bytes_ = data;
@@ -199,7 +212,7 @@ namespace ros {
             if( (checksum_%256) == 255)
 	      mode_++;
 	    else 
-	      mode_ = MODE_FIRST_FF;          /* abondan the frame if the msg len is wrong */
+	      mode_ = MODE_FIRST_FF;          /* Abandon the frame if the msg len is wrong */
 	  }else if( mode_ == MODE_TOPIC_L ){  /* bottom half of topic id */
             topic_ = data;
             mode_++;
@@ -387,7 +400,7 @@ namespace ros {
 
         /* setup the header */
         message_out[0] = 0xff;
-        message_out[1] = 0xff;
+        message_out[1] = PROTOCOL_VER;
         message_out[2] = (unsigned char) l&255;
         message_out[3] = (unsigned char) l>>8;
 	message_out[4] = 255 - ((message_out[2] + message_out[3])%256);

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -324,7 +324,7 @@ class SerialClient:
 	# The protocol version is sent as the 2nd sync byte emitted by each end
         self.protocol_ver1 = '\xff'
         self.protocol_ver2 = '\xfe'
-	self.protocol_ver = self.protocol_ver2
+        self.protocol_ver = self.protocol_ver2
 
         self.publishers = dict()  # id:Publishers
         self.subscribers = dict() # topic:Subscriber
@@ -362,10 +362,10 @@ class SerialClient:
         data = ''
         while not rospy.is_shutdown():
             if (rospy.Time.now() - self.lastsync).to_sec() > (self.timeout * 3):
-	        if (self.synced == True):
-		    rospy.logerr("Lost sync with device, restarting...")
+                if (self.synced == True):
+                    rospy.logerr("Lost sync with device, restarting...")
 		else:
-		    rospy.logerr("Unable to sync with device; possible link problem or link software version mismatch such as hydro rosserial_python with groovy Arduino")
+                    rospy.logerr("Unable to sync with device; possible link problem or link software version mismatch such as hydro rosserial_python with groovy Arduino")
                 self.lastsync_lost = rospy.Time.now()
                 self.sendDiagnostics(diagnostic_msgs.msg.DiagnosticStatus.ERROR, "no sync with device")
                 self.requestTopics()
@@ -601,7 +601,7 @@ class SerialClient:
                 return -1
             else:
                 #modified frame : header(2 bytes) + msg_len(2 bytes) + msg_len_chk(1 byte) + topic_id(2 bytes) + msg(x bytes) + msg_topic_id_chk(1 byte)
-		# second byte of header is protocol version
+                # second byte of header is protocol version
                 msg_len_checksum = 255 - ( ((length&255) + (length>>8))%256 )
                 msg_checksum = 255 - ( ((topic&255) + (topic>>8) + sum([ord(x) for x in msg]))%256 )
                 data = "\xff" + self.protocol_ver  + chr(length&255) + chr(length>>8) + chr(msg_len_checksum) + chr(topic&255) + chr(topic>>8)

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -321,7 +321,7 @@ class SerialClient:
         time.sleep(0.1)           # Wait for ready (patch for Uno)
 
         # hydro introduces protocol ver2 which must match node_handle.h
-	# The protocol version is sent as the 2nd sync byte emitted by each end
+        # The protocol version is sent as the 2nd sync byte emitted by each end
         self.protocol_ver1 = '\xff'
         self.protocol_ver2 = '\xfe'
         self.protocol_ver = self.protocol_ver2
@@ -364,7 +364,7 @@ class SerialClient:
             if (rospy.Time.now() - self.lastsync).to_sec() > (self.timeout * 3):
                 if (self.synced == True):
                     rospy.logerr("Lost sync with device, restarting...")
-		else:
+                else:
                     rospy.logerr("Unable to sync with device; possible link problem or link software version mismatch such as hydro rosserial_python with groovy Arduino")
                 self.lastsync_lost = rospy.Time.now()
                 self.sendDiagnostics(diagnostic_msgs.msg.DiagnosticStatus.ERROR, "no sync with device")
@@ -379,7 +379,12 @@ class SerialClient:
             if ( flag[1] != self.protocol_ver):
                 self.sendDiagnostics(diagnostic_msgs.msg.DiagnosticStatus.ERROR, "Mismatched protocol version in packet: lost sync or rosserial_python is from different ros release than the rosserial client")
                 rospy.logerr("Mismatched protocol version in packet: lost sync or rosserial_python is from different ros release than the rosserial client")
-                rospy.loginfo("Protocol version was %s, expected %s " % (flag[1], self.protocol_ver))
+                protocol_ver_msgs = {'\xff': 'Rev 0 (rosserial 0.4 and earlier)', '\xfe': 'Rev 1 (rosserial 0.5+)', '\xfd': 'Some future rosserial version'}
+                if (flag[1] in protocol_ver_msgs):
+                    found_ver_msg = 'Protocol version of client is ' + protocol_ver_msgs[flag[1]]
+                else:
+                    found_ver_msg = "Protocol version of client is unrecognized"
+                rospy.loginfo("%s, expected %s" % (found_ver_msg, protocol_ver_msgs[self.protocol_ver]))
                 continue
             msg_len_bytes = self.port.read(2)
             if len(msg_len_bytes) != 2:


### PR DESCRIPTION
Introduced protocol version in 2nd byte of messages. 

@mikeferguson, please have a look at the change in node_handle.h to pre-enable the NEXT protocol change to be detected by rosserial_python: if client detects a protocol mismatch when configured_ is false, it sends a requestTimeSync() message. This will be ignored in the case of protocol mismatch, and seems it should be harmless if the protocol mismatch was due to data corruption and in fact there is not a protocol mismatch. 

@MikePurvis - thanks for suggestion to send a "trial message" using old protocol. I didn't go that route because the protocol is stateless at present - that would have made it stateful inasmuch as each side would have had to go from an uninitialized state to an initialized state  in sync with the other and I'm worried about a bunch of corner cases popping out of that where one side is initialized and the other not, and recovery from that. Seems like a can of worms. Instead I opted for the best messages I could emit to suggest that there might be a protocol mismatch in the case of non-response.
