### PR TITLE
Fixed misalignment for 32 bit architectures

### DIFF
--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -170,15 +170,16 @@ class StringDataType(PrimitiveDataType):
 
     def serialize(self, f):
         cn = self.name.replace("[","").replace("]","")
-        f.write('      uint32_t * length_%s = (uint32_t *)(outbuffer + offset);\n' % cn)
-        f.write('      *length_%s = strlen( (const char*) this->%s);\n' % (cn,self.name))
+        f.write('      size_t length_%s = strlen( (const char*) this->%s);\n' % (cn,self.name))
+        f.write('      memcpy(outbuffer + offset, &length_%s, sizeof(size_t));\n' % cn)        
         f.write('      offset += 4;\n')
-        f.write('      memcpy(outbuffer + offset, this->%s, *length_%s);\n' % (self.name,cn))
-        f.write('      offset += *length_%s;\n' % cn)
+        f.write('      memcpy(outbuffer + offset, this->%s, length_%s);\n' % (self.name,cn))
+        f.write('      offset += length_%s;\n' % cn)
 
     def deserialize(self, f):
         cn = self.name.replace("[","").replace("]","")
-        f.write('      uint32_t length_%s = *(uint32_t *)(inbuffer + offset);\n' % cn)
+        f.write('      size_t length_%s;\n' % cn)
+        f.write('      memcpy(&length_%s, (inbuffer + offset), sizeof(size_t));\n' % cn)
         f.write('      offset += 4;\n')
         f.write('      for(unsigned int k= offset; k< offset+length_%s; ++k){\n'%cn) #shift for null character
         f.write('          inbuffer[k-1]=inbuffer[k];\n')
@@ -186,7 +187,6 @@ class StringDataType(PrimitiveDataType):
         f.write('      inbuffer[offset+length_%s-1]=0;\n'%cn)
         f.write('      this->%s = (char *)(inbuffer + offset-1);\n' % self.name)
         f.write('      offset += length_%s;\n' % cn)
-
 
 class TimeDataType(PrimitiveDataType):
 


### PR DESCRIPTION
This should fix issue issue #10. It removes the hard cast from char\* to uint32_t\* that causes misalignment errors on a 32 bit architecture (e.g ARM). I've tested it on a ARMv9 (Phidget SBC) and it seems to work fine.
