### PR TITLE
fixed uninitialized arrays that would cause random segfaults

### DIFF
--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -115,7 +115,12 @@ namespace ros {
        * Setup Functions
        */
     public:
-      NodeHandle_() : configured_(false) {}
+      NodeHandle_() : configured_(false) {
+        memset(publishers, 0, sizeof(publishers));
+        memset(subscribers, 0, sizeof(subscribers));
+        memset(message_in, 0, sizeof(message_in));
+        memset(message_out,0, sizeof(message_out));
+      }
       
       Hardware* getHardware(){
         return &hardware_;

--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -120,6 +120,13 @@ namespace ros {
         memset(subscribers, 0, sizeof(subscribers));
         memset(message_in, 0, sizeof(message_in));
         memset(message_out,0, sizeof(message_out));
+        
+        req_param_resp.ints_length = 0;
+        req_param_resp.ints = NULL;
+        req_param_resp.floats_length = 0;
+        req_param_resp.floats = NULL;
+        req_param_resp.ints_length = 0;
+        req_param_resp.ints = NULL;
       }
       
       Hardware* getHardware(){


### PR DESCRIPTION
Without setting to zeros the publishers and subscribers arrays, adding a new one (via e.g. advertise) would place it in the wrong position causing segfauilts later on (e.g. during spinOnce).
