### PR TITLE
Inilining all the functions to allow compilation of files with multiple includes

### DIFF
--- a/rosserial_client/src/ros_lib/duration.cpp
+++ b/rosserial_client/src/ros_lib/duration.cpp
@@ -37,7 +37,7 @@
 
 namespace ros
 {
-  void normalizeSecNSecSigned(long &sec, long &nsec)
+  inline void normalizeSecNSecSigned(long &sec, long &nsec)
   {
     long nsec_part = nsec;
     long sec_part = sec;
@@ -56,7 +56,7 @@ namespace ros
     nsec = nsec_part;
   }
 
-  Duration& Duration::operator+=(const Duration &rhs)
+  inline Duration& Duration::operator+=(const Duration &rhs)
   {
     sec += rhs.sec;
     nsec += rhs.nsec;
@@ -64,14 +64,14 @@ namespace ros
     return *this;
   }
 
-  Duration& Duration::operator-=(const Duration &rhs){
+  inline Duration& Duration::operator-=(const Duration &rhs){
     sec += -rhs.sec;
     nsec += -rhs.nsec;
     normalizeSecNSecSigned(sec, nsec);
     return *this;
   }
 
-  Duration& Duration::operator*=(double scale){
+  inline Duration& Duration::operator*=(double scale){
     sec *= scale;
     nsec *= scale;
     normalizeSecNSecSigned(sec, nsec);

--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -115,7 +115,12 @@ namespace ros {
        * Setup Functions
        */
     public:
-      NodeHandle_() : configured_(false) {}
+      NodeHandle_() : configured_(false) {
+        memset(publishers, 0, sizeof(publishers));
+        memset(subscribers, 0, sizeof(subscribers));
+        memset(message_in, 0, sizeof(message_in));
+        memset(message_out,0, sizeof(message_out));
+      }
       
       Hardware* getHardware(){
         return &hardware_;

--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -115,19 +115,7 @@ namespace ros {
        * Setup Functions
        */
     public:
-      NodeHandle_() : configured_(false) {
-        memset(publishers, 0, sizeof(publishers));
-        memset(subscribers, 0, sizeof(subscribers));
-        memset(message_in, 0, sizeof(message_in));
-        memset(message_out,0, sizeof(message_out));
-        
-        req_param_resp.ints_length = 0;
-        req_param_resp.ints = NULL;
-        req_param_resp.floats_length = 0;
-        req_param_resp.floats = NULL;
-        req_param_resp.ints_length = 0;
-        req_param_resp.ints = NULL;
-      }
+      NodeHandle_() : configured_(false) {}
       
       Hardware* getHardware(){
         return &hardware_;

--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -431,6 +431,7 @@ namespace ros {
           return l;
         }else{
           logerror("Message from device dropped: message larger than buffer.");
+          return 0;
         }
       }
 
@@ -476,7 +477,7 @@ namespace ros {
         rosserial_msgs::RequestParamRequest req;
         req.name  = (char*)name;
         publish(TopicInfo::ID_PARAMETER_REQUEST, &req);
-        int end_time = hardware_.time() + time_out;
+        uint end_time = hardware_.time() + time_out;
         while(!param_recieved ){
           spinOnce();
           if (hardware_.time() > end_time) return false;

--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -115,19 +115,7 @@ namespace ros {
        * Setup Functions
        */
     public:
-      NodeHandle_() : configured_(false) {
-        memset(publishers, 0, sizeof(publishers));
-        memset(subscribers, 0, sizeof(subscribers));
-        memset(message_in, 0, sizeof(message_in));
-        memset(message_out,0, sizeof(message_out));
-        
-        req_param_resp.ints_length = 0;
-        req_param_resp.ints = NULL;
-        req_param_resp.floats_length = 0;
-        req_param_resp.floats = NULL;
-        req_param_resp.ints_length = 0;
-        req_param_resp.ints = NULL;
-      }
+      NodeHandle_() : configured_(false) {}
       
       Hardware* getHardware(){
         return &hardware_;
@@ -431,7 +419,6 @@ namespace ros {
           return l;
         }else{
           logerror("Message from device dropped: message larger than buffer.");
-          return 0;
         }
       }
 
@@ -477,7 +464,7 @@ namespace ros {
         rosserial_msgs::RequestParamRequest req;
         req.name  = (char*)name;
         publish(TopicInfo::ID_PARAMETER_REQUEST, &req);
-        uint end_time = hardware_.time() + time_out;
+        int end_time = hardware_.time() + time_out;
         while(!param_recieved ){
           spinOnce();
           if (hardware_.time() > end_time) return false;

--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -120,6 +120,13 @@ namespace ros {
         memset(subscribers, 0, sizeof(subscribers));
         memset(message_in, 0, sizeof(message_in));
         memset(message_out,0, sizeof(message_out));
+        
+        req_param_resp.ints_length = 0;
+        req_param_resp.ints = NULL;
+        req_param_resp.floats_length = 0;
+        req_param_resp.floats = NULL;
+        req_param_resp.ints_length = 0;
+        req_param_resp.ints = NULL;
       }
       
       Hardware* getHardware(){

--- a/rosserial_client/src/ros_lib/time.cpp
+++ b/rosserial_client/src/ros_lib/time.cpp
@@ -37,14 +37,14 @@
 
 namespace ros
 {
-  void normalizeSecNSec(unsigned long& sec, unsigned long& nsec){
+  inline void normalizeSecNSec(unsigned long& sec, unsigned long& nsec){
     unsigned long nsec_part= nsec % 1000000000UL;
     unsigned long sec_part = nsec / 1000000000UL;
     sec += sec_part;
     nsec = nsec_part;
   }
 
-  Time& Time::fromNSec(long t)
+  inline Time& Time::fromNSec(long t)
   {
     sec = t / 1000000000;
     nsec = t % 1000000000;
@@ -52,7 +52,7 @@ namespace ros
     return *this;
   }
 
-  Time& Time::operator +=(const Duration &rhs)
+  inline Time& Time::operator +=(const Duration &rhs)
   {
     sec += rhs.sec;
     nsec += rhs.nsec;
@@ -60,7 +60,7 @@ namespace ros
     return *this; 
   }
 
-  Time& Time::operator -=(const Duration &rhs){
+  inline Time& Time::operator -=(const Duration &rhs){
     sec += -rhs.sec;
     nsec += -rhs.nsec;
     normalizeSecNSec(sec, nsec);

--- a/rosserial_embeddedlinux/src/ros_lib/embedded_linux_comms.c
+++ b/rosserial_embeddedlinux/src/ros_lib/embedded_linux_comms.c
@@ -26,13 +26,13 @@
 
 #define DEFAULT_PORTNUM 11411
 
-void error(const char *msg)
+inline void error(const char *msg)
 {
     perror(msg);
     exit(0);
 }
 
-void set_nonblock(int socket)
+inline void set_nonblock(int socket)
 {
 int flags;
 flags = fcntl(socket,F_GETFL,0);
@@ -40,7 +40,7 @@ assert(flags != -1);
 fcntl(socket, F_SETFL, flags | O_NONBLOCK);
 }
 
-int elCommInit(char *portName, int baud)
+inline int elCommInit(char *portName, int baud)
 {
 	struct termios options;
 	int fd;
@@ -130,7 +130,7 @@ int elCommInit(char *portName, int baud)
 	return -1;
 }
 
-int elCommRead(int fd)
+inline int elCommRead(int fd)
 {
 	unsigned char c;
 	unsigned int i;
@@ -146,7 +146,7 @@ int elCommRead(int fd)
 	return rv;				// return -1 or 0 either if we read nothing, or if read returned negative
 }
 
-int elCommWrite(int fd, uint8_t* data, int len)
+inline int elCommWrite(int fd, uint8_t* data, int len)
 {
 	int rv;
 	int length = len;


### PR DESCRIPTION
Right now if you try to compile together two files a.cpp and b.cpp, both of which `#include <ros.h>`, the linking phase will fail given that all the functions in the cpp files are defined twice. The reason is that some header files include cpp files, a choice that I fail to understand.

Ideally one should have everything in header files, but this fix allows cpp files to exist and a library to be created (as in the [wiki page](http://wiki.ros.org/rosserial_embeddedlinux/Tutorials/Advanced%20Techniques#Building_rosserial_embeddedlinux_as_a_library) ).

**Note for code size**: usually inlining code increases the code size (not necessarily!). However, considering that most of the rosserial library is already header only, therefore inlined by default, the additional functions should not make a substantial difference.

**Note for additional commit**: The file node_handle.h is modified by a different fix which is already the subject of pull request #62.
