### PR TITLE
Arduino Leonardo USB Serial Port

### DIFF
--- a/rosserial_arduino/src/ros_lib/ArduinoHardware.h
+++ b/rosserial_arduino/src/ros_lib/ArduinoHardware.h
@@ -44,7 +44,10 @@
 #ifdef _SAM3XA_
   #include <UARTClass.h>  // Arduino Due
   #define SERIAL_CLASS UARTClass
-#else
+#elif defined(USE_USBCON)
+  // Arduino Leonardo USB Serial Port
+  #define SERIAL_CLASS Serial_
+#else 
   #include <HardwareSerial.h>  // Arduino AVR
   #define SERIAL_CLASS HardwareSerial
 #endif
@@ -57,7 +60,7 @@ class ArduinoHardware {
     }
     ArduinoHardware()
     {
-#if defined(USBCON)
+#if defined(USBCON) and !(defined(USE_USBCON))
       /* Leonardo support */
       iostream = &Serial1;
 #else


### PR DESCRIPTION
Added a Preprocessor option to use the USB serial port built into the Leonardo processor rather than the secondary UART. 

I think this should be the default but I don't want to break anyone's system. :)
