### PR TITLE
Leonardo: Use the USB serial port for ROS messages option

### DIFF
--- a/rosserial_arduino/src/ros_lib/ArduinoHardware.h
+++ b/rosserial_arduino/src/ros_lib/ArduinoHardware.h
@@ -44,7 +44,10 @@
 #ifdef _SAM3XA_
   #include <UARTClass.h>  // Arduino Due
   #define SERIAL_CLASS UARTClass
-#else
+#elif defined(USE_USBCON)
+  // Arduino Leonardo USB Serial Port
+  #define SERIAL_CLASS Serial_
+#else 
   #include <HardwareSerial.h>  // Arduino AVR
   #define SERIAL_CLASS HardwareSerial
 #endif
@@ -57,7 +60,7 @@ class ArduinoHardware {
     }
     ArduinoHardware()
     {
-#if defined(USBCON)
+#if defined(USBCON) and !(defined(USE_USBCON))
       /* Leonardo support */
       iostream = &Serial1;
 #else
@@ -77,6 +80,10 @@ class ArduinoHardware {
     int getBaud(){return baud_;}
 
     void init(){
+#if defined(USE_USBCON)
+      // Startup delay as a fail-safe to upload a new sketch
+      delay(3000); 
+#endif
       iostream->begin(baud_);
     }
 

--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -170,16 +170,16 @@ class StringDataType(PrimitiveDataType):
 
     def serialize(self, f):
         cn = self.name.replace("[","").replace("]","")
-        f.write('      size_t length_%s = strlen( (const char*) this->%s);\n' % (cn,self.name))
-        f.write('      memcpy(outbuffer + offset, &length_%s, sizeof(size_t));\n' % cn)        
+        f.write('      uint32_t length_%s = strlen( (const char*) this->%s);\n' % (cn,self.name))
+        f.write('      memcpy(outbuffer + offset, &length_%s, sizeof(uint32_t));\n' % cn)        
         f.write('      offset += 4;\n')
         f.write('      memcpy(outbuffer + offset, this->%s, length_%s);\n' % (self.name,cn))
         f.write('      offset += length_%s;\n' % cn)
 
     def deserialize(self, f):
         cn = self.name.replace("[","").replace("]","")
-        f.write('      size_t length_%s;\n' % cn)
-        f.write('      memcpy(&length_%s, (inbuffer + offset), sizeof(size_t));\n' % cn)
+        f.write('      uint32_t length_%s;\n' % cn)
+        f.write('      memcpy(&length_%s, (inbuffer + offset), sizeof(uint32_t));\n' % cn)
         f.write('      offset += 4;\n')
         f.write('      for(unsigned int k= offset; k< offset+length_%s; ++k){\n'%cn) #shift for null character
         f.write('          inbuffer[k-1]=inbuffer[k];\n')


### PR DESCRIPTION
Added the ability to use the USB serial port for ROS messages.

Note that I added a fail-safe start-up delay to prevent a condition where the serial link becomes flooded and the user wouldn't be able to upload new code without a hardware reset procedure that took me a few hours to figure out.... :)
