### PR TITLE
Use stream logging in rosserial_server

### DIFF
--- a/rosserial_server/src/AsyncReadBuffer.h
+++ b/rosserial_server/src/AsyncReadBuffer.h
@@ -52,7 +52,7 @@ public:
   void read(size_t read_count, boost::function<void(ros::serialization::IStream&)> callback) {
      if (read_count > mem_.size()) {
       // Insufficient room in the buffer for the requested bytes,
-      ROS_ERROR_NAMED("async_read", "Requested to read %d bytes, but buffer capacity is only %d.", read_count, mem_.size());
+      ROS_ERROR_STREAM_NAMED("async_read", "Requested to read " << read_count << " bytes, but buffer capacity is only " << mem_.size() << ".");
       error_callback_(boost::system::errc::make_error_code(boost::system::errc::no_buffer_space));
       return;
     }
@@ -72,7 +72,7 @@ private:
     if (error) {
       error_callback_(error);
     } else {
-      ROS_DEBUG_NAMED("async_read", "Transferred %d byte(s).", bytes_transferred);
+      ROS_DEBUG_STREAM_NAMED("async_read", "Transferred " << bytes_transferred << " byte(s).");
 
       ros::serialization::IStream stream(&mem_[0], bytes_transferred);
       ROS_ASSERT_MSG(callback, "Bad read callback function.");

--- a/rosserial_server/src/serial_node.cpp
+++ b/rosserial_server/src/serial_node.cpp
@@ -83,7 +83,7 @@ private:
   void connect_with_reconnection(bool log_errors = true) {
     if (!attempt_connection(log_errors)) {  
       if (log_errors) {
-        ROS_INFO("Attempting reconnection every %lld ms.", interval_.total_milliseconds());
+        ROS_INFO_STREAM("Attempting reconnection every " << interval_.total_milliseconds() << " ms.");
       }
       timer_.expires_from_now(interval_);
       timer_.async_wait(boost::bind(&SerialSession::connect_with_reconnection, this, false));


### PR DESCRIPTION
to avoid problems with printfing size_t and similar types.
