### PR TITLE
rosserial_arduino support for Teensy 3.0 and 3.1

### DIFF
--- a/rosserial_arduino/src/ros_lib/ArduinoHardware.h
+++ b/rosserial_arduino/src/ros_lib/ArduinoHardware.h
@@ -41,8 +41,8 @@
   #include <WProgram.h>  // Arduino 0022
 #endif
 
-#if defined(__MK20DX128__) 
-  #include <usb_serial.h>  // Teensy 3.0
+#if defined(__MK20DX128__) || defined(__MK20DX256__)
+  #include <usb_serial.h>  // Teensy 3.0 and 3.1
   #define SERIAL_CLASS usb_serial_class
 #elif defined(_SAM3XA_)
   #include <UARTClass.h>  // Arduino Due

--- a/rosserial_arduino/src/ros_lib/ArduinoHardware.h
+++ b/rosserial_arduino/src/ros_lib/ArduinoHardware.h
@@ -41,7 +41,10 @@
   #include <WProgram.h>  // Arduino 0022
 #endif
 
-#ifdef _SAM3XA_
+#if defined(__MK20DX128__) 
+  #include <usb_serial.h>  // Teensy 3.0
+  #define SERIAL_CLASS usb_serial_class
+#elif defined(_SAM3XA_)
   #include <UARTClass.h>  // Arduino Due
   #define SERIAL_CLASS UARTClass
 #else


### PR DESCRIPTION
Added an extra #if to ArduinoHardware.h to check for Teensy 3.x compiler flags (**MK20DX128/256**) when using Teensyduino. Ensures that the USB serial connection is used instead of an onboard UART.

Tested and works with Arduino 1.0.5 and Teensyduino 1.15-1.17 on Ubuntu 13.10 with ROS Hydro.
