### PR TITLE
make tf topic absolute instead of relative

### DIFF
--- a/rosserial_client/src/ros_lib/tf/transform_broadcaster.h
+++ b/rosserial_client/src/ros_lib/tf/transform_broadcaster.h
@@ -43,7 +43,7 @@ namespace tf
   class TransformBroadcaster
   {
     public:
-      TransformBroadcaster() : publisher_("tf", &internal_msg) {}
+      TransformBroadcaster() : publisher_("/tf", &internal_msg) {}
 
       void init(ros::NodeHandle &nh)
       {


### PR DESCRIPTION
prevents accidental remapping via <group> tag in roslaunch
