### PR TITLE
Use const char* instead of char* for strings in messages.

### DIFF
--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -166,11 +166,11 @@ class StringDataType(PrimitiveDataType):
     """ Need to convert to signed char *. """
 
     def make_declaration(self, f):
-        f.write('      char * %s;\n' % self.name)
+        f.write('      const char* %s;\n' % self.name)
 
     def serialize(self, f):
         cn = self.name.replace("[","").replace("]","")
-        f.write('      uint32_t length_%s = strlen( (const char*) this->%s);\n' % (cn,self.name))
+        f.write('      uint32_t length_%s = strlen(this->%s);\n' % (cn,self.name))
         f.write('      memcpy(outbuffer + offset, &length_%s, sizeof(uint32_t));\n' % cn)        
         f.write('      offset += 4;\n')
         f.write('      memcpy(outbuffer + offset, this->%s, length_%s);\n' % (self.name,cn))


### PR DESCRIPTION
The present implementation has GCC complaining thusly:

```
warning: deprecated conversion from string constant to 'char*' [-Wwrite-strings]
     feedback_msg_.header.frame_id = "base_link";
```

Seems to compile and do the right thing for me.
