### PR TITLE
Remove include of ros.h from time.cpp

### DIFF
--- a/rosserial_client/src/ros_lib/time.cpp
+++ b/rosserial_client/src/ros_lib/time.cpp
@@ -32,7 +32,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "ros.h"
 #include "ros/time.h"
 
 namespace ros


### PR DESCRIPTION
It compiles fine without it— it being here is a pain because there's an assumption that the client library's "ros.h" file will be in the include path, whereas a client library might prefer it as "ros/ros.h" or something else entirely.

Is there some historical reason this was here? @mikeferguson 
