### PR TITLE
Service client support for rosserial-server

### DIFF
--- a/rosserial_msgs/CMakeLists.txt
+++ b/rosserial_msgs/CMakeLists.txt
@@ -11,9 +11,8 @@ add_message_files(FILES
 add_service_files(FILES
                   RequestParam.srv
                   RequestMessageInfo.srv
+                  RequestServiceInfo.srv
                  )
 
 generate_messages()
-
 catkin_package(CATKIN_DEPENDS message_runtime)
-

--- a/rosserial_msgs/srv/RequestServiceInfo.srv
+++ b/rosserial_msgs/srv/RequestServiceInfo.srv
@@ -1,0 +1,6 @@
+# service name
+string service
+---
+# If found, return md5 string of system's version of the service, and
+# textual definition. If not found, both strings are to be empty.
+string md5

--- a/rosserial_msgs/srv/RequestServiceInfo.srv
+++ b/rosserial_msgs/srv/RequestServiceInfo.srv
@@ -1,6 +1,4 @@
 # service name
 string service
 ---
-# If found, return md5 string of system's version of the service, and
-# textual definition. If not found, both strings are to be empty.
 string md5

--- a/rosserial_msgs/srv/RequestServiceInfo.srv
+++ b/rosserial_msgs/srv/RequestServiceInfo.srv
@@ -1,4 +1,6 @@
 # service name
 string service
 ---
-string md5
+string service_md5
+string request_md5
+string response_md5

--- a/rosserial_python/nodes/message_info_service.py
+++ b/rosserial_python/nodes/message_info_service.py
@@ -70,15 +70,14 @@ class MessageInfoService(object):
 
   def _service_info_cb(self, req):
     rospy.logdebug("req.service is %s" % req.service)
-    package_message = tuple(req.service.split("/"))
-    if not self.service_cache.has_key(package_message):
-      rospy.loginfo("Loading module to return info on service %s/%s." % package_message)
-      srv = load_service(*package_message)
-      self.service_cache[package_message] = (srv._md5sum)
+    package_service = tuple(req.service.split("/"))
+    if not self.service_cache.has_key(package_service):
+      rospy.loginfo("Loading module to return info on service %s/%s." % package_service)
+      srv = load_service(*package_service)
+      self.service_cache[package_service] = (srv._md5sum)
     else:
-      rospy.loginfo("Returning info from cache on %s/%s." % package_message)
-      rospy.logdebug("moo: %s" % str(dir(self.service_cache[package_message])))
-    return self.service_cache[package_message]
+      rospy.loginfo("Returning info from cache on %s/%s." % package_service)
+    return self.service_cache[package_service]
 
   def spin(self):
     rospy.spin()

--- a/rosserial_python/nodes/message_info_service.py
+++ b/rosserial_python/nodes/message_info_service.py
@@ -73,8 +73,8 @@ class MessageInfoService(object):
     package_service = tuple(req.service.split("/"))
     if not self.service_cache.has_key(package_service):
       rospy.loginfo("Loading module to return info on service %s/%s." % package_service)
-      srv = load_service(*package_service)
-      self.service_cache[package_service] = (srv._md5sum)
+      srv,mreq,mres = load_service(*package_service)
+      self.service_cache[package_service] = (srv._md5sum,mreq._md5sum,mres._md5sum)
     else:
       rospy.loginfo("Returning info from cache on %s/%s." % package_service)
     return self.service_cache[package_service]

--- a/rosserial_python/nodes/message_info_service.py
+++ b/rosserial_python/nodes/message_info_service.py
@@ -43,7 +43,9 @@ This allows rosserial_server to be distributed in binary form. """
 
 import rospy
 from rosserial_msgs.srv import RequestMessageInfo
+from rosserial_msgs.srv import RequestServiceInfo
 from rosserial_python import load_message
+from rosserial_python import load_service
 
 
 class MessageInfoService(object):
@@ -51,19 +53,32 @@ class MessageInfoService(object):
   def __init__(self):
     rospy.init_node("message_info_service")
     rospy.loginfo("rosserial message_info_service node")
-    self.service = rospy.Service("message_info", RequestMessageInfo, self._cb)
-    self.cache = {}
-  
-  def _cb(self, req):
+    self.service = rospy.Service("message_info", RequestMessageInfo, self._message_info_cb)
+    self.serviceInfoService = rospy.Service("service_info", RequestServiceInfo, self._service_info_cb)
+    self.message_cache = {}
+    self.service_cache = {}
+
+  def _message_info_cb(self, req):
     package_message = tuple(req.type.split("/"))
-    if not self.cache.has_key(package_message):
+    if not self.message_cache.has_key(package_message):
       rospy.loginfo("Loading module to return info on %s/%s." % package_message)
       msg = load_message(*package_message)
-      self.cache[package_message] = (msg._md5sum, msg._full_text)
+      self.message_cache[package_message] = (msg._md5sum, msg._full_text)
     else:
       rospy.loginfo("Returning info from cache on %s/%s." % package_message)
+    return self.message_cache[package_message]
 
-    return self.cache[package_message]
+  def _service_info_cb(self, req):
+    rospy.logdebug("req.service is %s" % req.service)
+    package_message = tuple(req.service.split("/"))
+    if not self.service_cache.has_key(package_message):
+      rospy.loginfo("Loading module to return info on service %s/%s." % package_message)
+      srv = load_service(*package_message)
+      self.service_cache[package_message] = (srv._md5sum)
+    else:
+      rospy.loginfo("Returning info from cache on %s/%s." % package_message)
+      rospy.logdebug("moo: %s" % str(dir(self.service_cache[package_message])))
+    return self.service_cache[package_message]
 
   def spin(self):
     rospy.spin()

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -78,6 +78,13 @@ def load_message(package, message):
     m2 = getattr(m, 'msg')
     return getattr(m2, message)
 
+def load_service(package,service):
+    s = load_pkg_module(package, 'srv')
+    s = getattr(s, 'srv')
+    srv = getattr(s, service)
+    rospy.logdebug("srv contains " + str(dir(srv)))
+    return srv
+
 class Publisher:
     """
         Publisher forwards messages from the serial device to ROS.
@@ -121,7 +128,7 @@ class Subscriber:
 
     def unregister(self):
         rospy.loginfo("Removing subscriber: %s", self.topic)
-        self.subscriber.unregister()            
+        self.subscriber.unregister()
 
     def callback(self, msg):
         """ Forward message to serial device. """
@@ -155,7 +162,7 @@ class ServiceServer:
 
     def unregister(self):
         rospy.loginfo("Removing service: %s", self.topic)
-        self.service.shutdown()                    
+        self.service.shutdown()
 
     def callback(self, req):
         """ Forward request to serial device. """
@@ -268,7 +275,7 @@ class RosSerialServer:
         rospy.loginfo("starting ROS Serial Python Node serial_node-%r" % (address,))
         rospy.init_node("serial_node_%r" % (address,))
         self.startSerialClient()
-     
+
     def flushInput(self):
          pass
 
@@ -298,7 +305,7 @@ class RosSerialServer:
 
     def close(self):
         self.port.close()
-        
+
     def inWaiting(self):
         try: # the caller checks just for <1, so we'll peek at just one byte
             chunk = self.socket.recv(1, socket.MSG_DONTWAIT|socket.MSG_PEEK)
@@ -388,7 +395,7 @@ class SerialClient:
     def txStopRequest(self, signal, frame):
         """ send stop tx request to arduino when receive SIGINT(Ctrl-c)"""
         self.port.flushInput()
-        self.port.write("\xff" + self.protocol_ver + "\x00\x00\xff\x0b\x00\xf4") 
+        self.port.write("\xff" + self.protocol_ver + "\x00\x00\xff\x0b\x00\xf4")
         # tx_stop_request is x0b
         rospy.loginfo("Send tx stop request")
         sys.exit(0)
@@ -429,10 +436,10 @@ class SerialClient:
 
                 flag = [0,0]
                 flag[0] = self.tryRead(1)
-                if (flag[0] != '\xff'):                
+                if (flag[0] != '\xff'):
                     continue
 
-                flag[1] = self.tryRead(1) 
+                flag[1] = self.tryRead(1)
                 if ( flag[1] != self.protocol_ver):
                     self.sendDiagnostics(diagnostic_msgs.msg.DiagnosticStatus.ERROR, "Mismatched protocol version in packet: lost sync or rosserial_python is from different ros release than the rosserial client")
                     rospy.logerr("Mismatched protocol version in packet: lost sync or rosserial_python is from different ros release than the rosserial client")
@@ -446,7 +453,7 @@ class SerialClient:
 
                 msg_len_bytes = self.tryRead(2)
                 msg_length, = struct.unpack("<h", msg_len_bytes)
-     
+
                 msg_len_chk = self.tryRead(1)
                 msg_len_checksum = sum(map(ord, msg_len_bytes)) + ord(msg_len_chk)
 
@@ -515,14 +522,14 @@ class SerialClient:
             msg = TopicInfo()
             msg.deserialize(data)
             if not msg.topic_name in self.subscribers.keys():
-                sub = Subscriber(msg, self) 
+                sub = Subscriber(msg, self)
                 self.subscribers[msg.topic_name] = sub
                 self.setSubscribeSize(msg.buffer_size)
                 rospy.loginfo("Setup subscriber on %s [%s]" % (msg.topic_name, msg.message_type) )
             elif msg.message_type != self.subscribers[msg.topic_name].message._type:
                 old_message_type = self.subscribers[msg.topic_name].message._type
                 self.subscribers[msg.topic_name].unregister()
-                sub = Subscriber(msg, self) 
+                sub = Subscriber(msg, self)
                 self.subscribers[msg.topic_name] = sub
                 self.setSubscribeSize(msg.buffer_size)
                 rospy.loginfo("Change the message type of subscriber on %s from [%s] to [%s]" % (msg.topic_name, old_message_type, msg.message_type) )
@@ -611,7 +618,7 @@ class SerialClient:
         t.serialize(data_buffer)
         self.send( TopicInfo.ID_TIME, data_buffer.getvalue() )
         self.lastsync = rospy.Time.now()
-        
+
 
     def handleParameterRequest(self, data):
         """ Send parameters to device. Supports only simple datatypes and arrays of such. """
@@ -704,4 +711,3 @@ class SerialClient:
         status.values[1].value=time.ctime(self.lastsync_lost.to_sec())
 
         self.pub_diagnostics.publish(msg)
-

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -82,7 +82,9 @@ def load_service(package,service):
     s = load_pkg_module(package, 'srv')
     s = getattr(s, 'srv')
     srv = getattr(s, service)
-    return srv
+    mreq = getattr(s, service+"Request")
+    mres = getattr(s, service+"Response")
+    return srv,mreq,mres
 
 class Publisher:
     """

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -82,7 +82,6 @@ def load_service(package,service):
     s = load_pkg_module(package, 'srv')
     s = getattr(s, 'srv')
     srv = getattr(s, service)
-    rospy.logdebug("srv contains " + str(dir(srv)))
     return srv
 
 class Publisher:

--- a/rosserial_server/src/Session.h
+++ b/rosserial_server/src/Session.h
@@ -401,7 +401,6 @@ private:
       callbacks_[topic_info.topic_id] = boost::bind(&ServiceClient::handle, srv, _1);
     }
     if (services_[topic_info.topic_name]->getRequestMessageMD5() != topic_info.md5sum) {
-      // TODO coherent error message
       ROS_WARN("Service client setup: Request message MD5 mismatch between rosserial client and ROS");
     } else {
       ROS_DEBUG("Service client %s: request message MD5 successfully validated as %s",
@@ -424,7 +423,6 @@ private:
     // see above comment regarding the service client callback for why we set topic_id here
     services_[topic_info.topic_name]->setTopicId(topic_info.topic_id);
     if (services_[topic_info.topic_name]->getResponseMessageMD5() != topic_info.md5sum) {
-      // TODO coherent error message
       ROS_WARN("Service client setup: Response message MD5 mismatch between rosserial client and ROS");
     } else {
       ROS_DEBUG("Service client %s: response message MD5 successfully validated as %s",

--- a/rosserial_server/src/Session.h
+++ b/rosserial_server/src/Session.h
@@ -400,6 +400,13 @@ private:
       services_[topic_info.topic_name] = srv;
       callbacks_[topic_info.topic_id] = boost::bind(&ServiceClient::handle, srv, _1);
     }
+    if (services_[topic_info.topic_name]->getRequestMessageMD5() != topic_info.md5sum) {
+      // TODO coherent error message
+      ROS_WARN("Service client setup: Request message MD5 mismatch between rosserial client and ROS");
+    } else {
+      ROS_DEBUG("Service client %s: request message MD5 successfully validated as %s",
+        topic_info.topic_name.c_str(),topic_info.md5sum.c_str());
+    }
     set_sync_timeout(timeout_interval_);
   }
 
@@ -416,6 +423,13 @@ private:
     }
     // see above comment regarding the service client callback for why we set topic_id here
     services_[topic_info.topic_name]->setTopicId(topic_info.topic_id);
+    if (services_[topic_info.topic_name]->getResponseMessageMD5() != topic_info.md5sum) {
+      // TODO coherent error message
+      ROS_WARN("Service client setup: Response message MD5 mismatch between rosserial client and ROS");
+    } else {
+      ROS_DEBUG("Service client %s: response message MD5 successfully validated as %s",
+        topic_info.topic_name.c_str(),topic_info.md5sum.c_str());
+    }
     set_sync_timeout(timeout_interval_);
   }
 

--- a/rosserial_server/src/topic_handlers.h
+++ b/rosserial_server/src/topic_handlers.h
@@ -138,21 +138,25 @@ public:
     info.request.service = topic_info.message_type;
     ROS_DEBUG("Calling service_info service for topic name %s",topic_info.topic_name.c_str());
     if (service_info_service_.call(info)) {
-      if (info.response.md5 != topic_info.md5sum) {
-        // ROS_WARN_STREAM("Message" << topic_info.message_type  << "MD5 sum from client does not match that in system. Will avoid using system's message definition.");
-        // info.response.definition = "";
-      }
+      request_message_md5_ = info.response.request_md5;
+      response_message_md5_ = info.response.response_md5;
     } else {
       ROS_WARN("Failed to call service_info service. The service client will be created with blank md5sum.");
     }
     ros::ServiceClientOptions opts;
     opts.service = topic_info.topic_name;
-    opts.md5sum = service_md5_ = info.response.md5;
+    opts.md5sum = service_md5_ = info.response.service_md5;
     opts.persistent = false; // always false for now
     service_client_ = nh.serviceClient(opts);
   }
   void setTopicId(uint16_t topic_id) {
     topic_id_ = topic_id;
+  }
+  std::string getRequestMessageMD5() {
+    return request_message_md5_;
+  }
+  std::string getResponseMessageMD5() {
+    return response_message_md5_;
   }
 
 private:
@@ -179,6 +183,8 @@ private:
   static ros::ServiceClient service_info_service_;
   boost::function<void(std::vector<uint8_t> buffer, const uint16_t topic_id)> write_fn_;
   std::string service_md5_;
+  std::string request_message_md5_;
+  std::string response_message_md5_;
   uint16_t topic_id_;
 };
 

--- a/rosserial_server/src/topic_handlers.h
+++ b/rosserial_server/src/topic_handlers.h
@@ -157,7 +157,6 @@ public:
 
 private:
   void handle(ros::serialization::IStream stream) {
-    ROS_INFO("Service call handler says hi");
     // deserialize request message
     ros::serialization::Serializer<topic_tools::ShapeShifter>::read(stream, request_message_);
 


### PR DESCRIPTION
Allows rosserial clients to register service clients and make service calls. Only tested with rosserial-windows so far.
