### PR TITLE
fix output of make_library when package has only messages

### DIFF
--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -519,6 +519,8 @@ def MakeLibrary(package, output_path, rospack):
                 md5res = roslib.message.get_service_class(package+'/'+f[0:-4])._response_class._md5sum
                 messages.append( Service(f[0:-4], package, definition, md5req, md5res ) )
         print('\n')
+    elif messages != list():
+        print('\n')
 
     # generate for each message
     output_path = output_path + "/" + package


### PR DESCRIPTION
Minor fix adds the newline when there are no services but there were messages (otherwise output is whacked out a bit).
