### PR TITLE
Move AVR serialization logic, add unit test

### DIFF
--- a/rosserial_client/CMakeLists.txt
+++ b/rosserial_client/CMakeLists.txt
@@ -14,3 +14,8 @@ install(DIRECTORY src/ros_lib
 install(PROGRAMS scripts/make_libraries
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
+
+if(CATKIN_ENABLE_TESTING)
+  include_directories(src)
+  catkin_add_gtest(float64_test test/float64_test.cpp)
+endif()

--- a/rosserial_client/src/ros_lib/ros/msg.h
+++ b/rosserial_client/src/ros_lib/ros/msg.h
@@ -35,18 +35,95 @@
 #ifndef _ROS_MSG_H_
 #define _ROS_MSG_H_
 
+#include <stdint.h>
+
 namespace ros {
 
-  /* Base Message Type */
-  class Msg
-  {
-    public:
-      virtual int serialize(unsigned char *outbuffer) const = 0;
-	  virtual int deserialize(unsigned char *data) = 0;
-      virtual const char * getType() = 0;
-      virtual const char * getMD5() = 0;
-  };
+/* Base Message Type */
+class Msg
+{
+public:
+  virtual int serialize(unsigned char *outbuffer) const = 0;
+  virtual int deserialize(unsigned char *data) = 0;
+  virtual const char * getType() = 0;
+  virtual const char * getMD5() = 0;
 
-}
+  /**
+   * @brief This tricky function handles promoting a 32bit float to a 64bit
+   *        double, so that AVR can publish messages containing float64
+   *        fields, despite AVV having no native support for double.
+   *
+   * @param[out] outbuffer pointer for buffer to serialize to.
+   * @param[in] f value to serialize.
+   *
+   * @return number of bytes to advance the buffer pointer.
+   *
+   */
+  static int serializeAvrFloat64(unsigned char* outbuffer, const float f)
+  {
+    const int32_t* val = (int32_t*) &f;
+    int32_t exp = ((*val >> 23) & 255);
+    if (exp != 0)
+    {
+      exp += 1023 - 127;
+    }
+
+    int32_t sig = *val;
+    *(outbuffer++) = 0;
+    *(outbuffer++) = 0;
+    *(outbuffer++) = 0;
+    *(outbuffer++) = (sig << 5) & 0xff;
+    *(outbuffer++) = (sig >> 3) & 0xff;
+    *(outbuffer++) = (sig >> 11) & 0xff;
+    *(outbuffer++) = ((exp << 4) & 0xF0) | ((sig >> 19) & 0x0F);
+    *(outbuffer++) = (exp >> 4) & 0x7F;
+
+    // Mark negative bit as necessary.
+    if (f < 0)
+    {
+      *(outbuffer - 1) |= 0x80;
+    }
+
+    return 8;
+  }
+
+  /**
+   * @brief This tricky function handles demoting a 64bit double to a
+   *        32bit float, so that AVR can understand messages containing
+   *        float64 fields, despite AVR having no native support for double.
+   *
+   * @param[in] inbuffer pointer for buffer to deserialize from.
+   * @param[out] f pointer to place the deserialized value in.
+   *
+   * @return number of bytes to advance the buffer pointer.
+   */
+  static int deserializeAvrFloat64(const unsigned char* inbuffer, float* f)
+  {
+    uint32_t* val = (uint32_t*)f;
+    inbuffer += 3;
+
+    // Copy truncated mantissa.
+    *val = ((uint32_t)(*(inbuffer++)) >> 5 & 0x07);
+    *val |= ((uint32_t)(*(inbuffer++)) & 0xff) << 3;
+    *val |= ((uint32_t)(*(inbuffer++)) & 0xff) << 11;
+    *val |= ((uint32_t)(*inbuffer) & 0x0f) << 19;
+
+    // Copy truncated exponent.
+    uint32_t exp = ((uint32_t)(*(inbuffer++)) & 0xf0)>>4;
+    exp |= ((uint32_t)(*inbuffer) & 0x7f) << 4;
+    if (exp != 0)
+    {
+      *val |= ((exp) - 1023 + 127) << 23;
+    }  
+
+    // Copy negative sign.
+    *val |= ((uint32_t)(*(inbuffer++)) & 0x80) << 24;
+
+    return 8;
+  }
+
+};
+
+}  // namespace ros
 
 #endif

--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -131,35 +131,11 @@ class AVR_Float64DataType(PrimitiveDataType):
         f.write('      float %s;\n' % self.name )
 
     def serialize(self, f):
-        cn = self.name.replace("[","").replace("]","")
-        f.write('      int32_t * val_%s = (int32_t *) &(this->%s);\n' % (cn,self.name))
-        f.write('      int32_t exp_%s = (((*val_%s)>>23)&255);\n' % (cn,cn))
-        f.write('      if(exp_%s != 0)\n' % cn)
-        f.write('        exp_%s += 1023-127;\n' % cn)
-        f.write('      int32_t sig_%s = *val_%s;\n' % (cn,cn))
-        f.write('      *(outbuffer + offset++) = 0;\n') # 29 blank bits
-        f.write('      *(outbuffer + offset++) = 0;\n')
-        f.write('      *(outbuffer + offset++) = 0;\n')
-        f.write('      *(outbuffer + offset++) = (sig_%s<<5) & 0xff;\n' % cn)
-        f.write('      *(outbuffer + offset++) = (sig_%s>>3) & 0xff;\n' % cn)
-        f.write('      *(outbuffer + offset++) = (sig_%s>>11) & 0xff;\n' % cn)
-        f.write('      *(outbuffer + offset++) = ((exp_%s<<4) & 0xF0) | ((sig_%s>>19)&0x0F);\n' % (cn,cn))
-        f.write('      *(outbuffer + offset++) = (exp_%s>>4) & 0x7F;\n' % cn)
-        f.write('      if(this->%s < 0) *(outbuffer + offset -1) |= 0x80;\n' % self.name)
+        f.write('      offset += serializeAvrFloat64(outbuffer + offset, this->%s);\n' % self.name)
 
     def deserialize(self, f):
-        cn = self.name.replace("[","").replace("]","")
-        f.write('      uint32_t * val_%s = (uint32_t*) &(this->%s);\n' % (cn,self.name))
-        f.write('      offset += 3;\n') # 29 blank bits
-        f.write('      *val_%s = ((uint32_t)(*(inbuffer + offset++))>>5 & 0x07);\n' % cn)
-        f.write('      *val_%s |= ((uint32_t)(*(inbuffer + offset++)) & 0xff)<<3;\n' % cn)
-        f.write('      *val_%s |= ((uint32_t)(*(inbuffer + offset++)) & 0xff)<<11;\n' % cn)
-        f.write('      *val_%s |= ((uint32_t)(*(inbuffer + offset)) & 0x0f)<<19;\n' % cn)
-        f.write('      uint32_t exp_%s = ((uint32_t)(*(inbuffer + offset++))&0xf0)>>4;\n' % cn)
-        f.write('      exp_%s |= ((uint32_t)(*(inbuffer + offset)) & 0x7f)<<4;\n' % cn)
-        f.write('      if(exp_%s !=0)\n' % cn)
-        f.write('        *val_%s |= ((exp_%s)-1023+127)<<23;\n' % (cn,cn))
-        f.write('      *val_%s |= (((uint32_t)(*(inbuffer+offset++)) & 0x80)<<24);\n' % (cn))
+        f.write('      offset += deserializeAvrFloat64(inbuffer + offset, &(this->%s));\n' % self.name)
+
 
 class StringDataType(PrimitiveDataType):
     """ Need to convert to signed char *. """

--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -159,8 +159,7 @@ class AVR_Float64DataType(PrimitiveDataType):
         f.write('      exp_%s |= ((uint32_t)(*(inbuffer + offset)) & 0x7f)<<4;\n' % cn)
         f.write('      if(exp_%s !=0)\n' % cn)
         f.write('        *val_%s |= ((exp_%s)-1023+127)<<23;\n' % (cn,cn))
-        f.write('      if( ((*(inbuffer+offset++)) & 0x80) > 0) this->%s = -this->%s;\n' % (self.name,self.name))
-
+        f.write('      *val_%s |= (((uint32_t)(*(inbuffer+offset++)) & 0x80)<<24);\n' % (cn))
 
 class StringDataType(PrimitiveDataType):
     """ Need to convert to signed char *. """

--- a/rosserial_client/test/float64_test.cpp
+++ b/rosserial_client/test/float64_test.cpp
@@ -1,0 +1,43 @@
+#include "ros_lib/ros/msg.h"
+#include <gtest/gtest.h>
+
+
+class TestFloat64 : public ::testing::Test
+{
+public:
+  union
+  {
+    double val;
+    unsigned char buffer[8];
+  };
+  
+  static const double cases[];
+  static const int num_cases;
+};
+ 
+const double TestFloat64::cases[] = {
+  0.0, 10.0, 15642.1, -50.2, 0.0001, -0.321,
+  123456.789, -987.654321, 3.4e38, -3.4e38,
+};
+const int TestFloat64::num_cases = sizeof(TestFloat64::cases) / sizeof(double);
+
+
+TEST_F(TestFloat64, testRoundTrip)
+{
+  for (int i = 0; i < num_cases; i++)
+  {
+    memset(buffer, 0, sizeof(buffer));
+    ros::Msg::serializeAvrFloat64(buffer, cases[i]);
+    EXPECT_FLOAT_EQ(cases[i], val);
+    
+    float ret = 0;
+    ros::Msg::deserializeAvrFloat64(buffer, &ret);
+    EXPECT_FLOAT_EQ(cases[i], ret);
+  }
+}
+
+
+int main(int argc, char **argv){
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This PR includes and supercedes #139.

As an additional obvious benefit, the serialization logic for Float64, if used, will appear only once in the binary, rather than once per field using it. If unused, it will be optimized away.

@mikeferguson, @PaulBouchier, @mgerdzhev, this look okay to you guys?
