### PR TITLE
Generate constructors for messages.

### DIFF
--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -210,7 +210,10 @@ class ArrayDataType(PrimitiveDataType):
         self.cls = cls
 
     def make_initializer(self, f, trailer):
-        f.write('      %s_length(0), %s(NULL)%s\n' % (self.name, self.name, trailer))
+        if self.size == None:
+            f.write('      %s_length(0), %s(NULL)%s\n' % (self.name, self.name, trailer))
+        else:
+            f.write('      %s()%s\n' % (self.name, self.name, trailer))
 
     def make_declaration(self, f):
         c = self.cls("*"+self.name, self.type, self.bytes)


### PR DESCRIPTION
This is going to bloat the microcontroller firmwares a wee bit, but right now we depend on undefined behaviour in that we assume that messages are going to be allocated on zeroed memory. It's particularly problematic for the length field on a subscriber to be non-zero, since that really confuses the logic that triggers a realloc when a larger sized array is received.

Situations where the message memory may not be zeroed: messages allocated on the stack, clients running on PCs, unit tests, etc.
