### PR TITLE
createQuaternionFromYaw should be static

### DIFF
--- a/rosserial_client/src/ros_lib/tf/tf.h
+++ b/rosserial_client/src/ros_lib/tf/tf.h
@@ -40,7 +40,7 @@
 namespace tf
 {
   
-  geometry_msgs::Quaternion createQuaternionFromYaw(double yaw)
+  static inline geometry_msgs::Quaternion createQuaternionFromYaw(double yaw)
   {
     geometry_msgs::Quaternion q;
     q.x = 0;


### PR DESCRIPTION
Fixes "multiple definition" error
