### PR TITLE
Bugfix for checksum.

### DIFF
--- a/rosserial_server/include/rosserial_server/session.h
+++ b/rosserial_server/include/rosserial_server/session.h
@@ -369,7 +369,7 @@ private:
   }
 
   static uint8_t checksum(uint16_t val) {
-    return (val >> 8) | val;
+    return (val >> 8) + val;
   }
 
   //// RECEIVED MESSAGE HANDLERS ////


### PR DESCRIPTION
Publishing topics fails when messages are over 255 bytes in length due to checksum() function or'ing high and low byte instead of adding them.
