### PR TITLE
Make error message more verbose and fail the build if message generation fails

### DIFF
--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -42,6 +42,7 @@ import roslib.srvs
 import roslib.message
 import rospkg
 import rospy
+import traceback
 
 import os, sys, subprocess, re
 
@@ -554,7 +555,7 @@ def get_dependency_sorted_package_list(rospack):
             if not dependent:
                 dependency_list.append(p)
         except rospkg.common.ResourceNotFound as e:
-            failed.append(p + " (missing dependency)")
+            failed.append(p + " (missing dependency: " + e.message + ")")
             print('[%s]: Unable to find dependency: %s. Messages cannot be built.\n'% (p, str(e)))
     dependency_list.reverse()
     return [dependency_list, failed]
@@ -572,13 +573,15 @@ def rosserial_generate(rospack, path, mapping):
         try:
             MakeLibrary(p, path, rospack)
         except Exception as e:
-            failed.append(p)
+            failed.append(p + " ("+str(e)+")")
             print('[%s]: Unable to build messages: %s\n' % (p, str(e)))
+            print(traceback.format_exc())
     print('\n')
     if len(failed) > 0:
         print('*** Warning, failed to generate libraries for the following packages: ***')
         for f in failed:
             print('    %s'%f)
+        raise Exception("Failed to generate libraries for: " + str(failed))
     print('\n')
 
 def rosserial_client_copy_files(rospack, path):


### PR DESCRIPTION
This makes the end build output when generating messages a little more verbose so you can see what's wrong without scrolling through all of the output.
This also raises an exception in order to fail the build. The fact that the build continues even when message generation fails makes it pretty hard to figure out what's going on when things do fail and leads to some weird error messages when not all messages are generated (because apparently the regular c++ message headers are also in the include path when building rosserial client code)
I figured this was the easiest way to make it work in most scenarios, but it could also simply return an error code and then each script that calls rosserial_generate would call exit on the return value of the function. This is a change in behavior so I understand if failing the build isn't desired.
