### PR TITLE
fixed queue size warning with diagnostics publisher

### DIFF
--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -333,7 +333,7 @@ class SerialClient:
         self.timeout = timeout
         self.synced = False
 
-        self.pub_diagnostics = rospy.Publisher('/diagnostics', diagnostic_msgs.msg.DiagnosticArray)
+        self.pub_diagnostics = rospy.Publisher('/diagnostics', diagnostic_msgs.msg.DiagnosticArray, queue_size=10)
 
         if port== None:
             # no port specified, listen for any new port?


### PR DESCRIPTION
Publisher gave error regarding missing queue size argument during initialization.
