### PR TITLE
added WiFi support for Arduino clients

### DIFF
--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -200,8 +200,17 @@ namespace ros {
         while( true )
         {
           int data = hardware_.read();
-          if( data < 0 )
+          if( data < 0 ) {
+#if defined(USE_WIFICON)
+		    if (!hardware_.isConnectionUp()) {		// check connection, if it is broken try to repair it N.B. should really add interrupt timer as this blocks !
+				configured_ = false;
+				return -3;
+			} else
+				break;
+#else
             break;
+#endif	    
+		  }
           checksum_ += data;
           if( mode_ == MODE_MESSAGE ){        /* message data being recieved */
             message_in[index_++] = data;


### PR DESCRIPTION
I have added the TCP socket connection method to the Arduino client part of your cool package.

Personally I have an ESP8266 chip -which has a specific WiFi arduino library- and have tested that it works for that. In theory it should work for other Arduino chips that use the refular WiFi.h library, but I have not been able to test it.

Quick user-guide on how to use it in the Arduino sketch: 
- "#include <WiFi.h>"
- "#define USE_WIFICON"
- bind to the access point with WiFi.setup(), as normal
- call nh.initNode(char\* hostname)

The initNode() will block until the TCP connection is created, retrying every 5 seconds.

The spinOnce() calls will detect broken TCP connections and try to restore the connection if it is broken (in a blocking way unfortunately). If it can not restore the connection immediately, it spinOnce() returns -3.

With the advent of the ESP8266 chip, I'm figuring that having WiFi capability in the Arduino part of your package is going to be in demand. But I'm  not really a big-time developer, and never use git so buyer beware =) If it looks interesting, feel free to include the changes.

Best regards, and thanks again for your wonderful package!
