### PR TITLE
Support for TI's TM4C123GXL and TM4C129XL evaluation boards.

### DIFF
--- a/rosserial_tivac/CHANGELOG.rst
+++ b/rosserial_tivac/CHANGELOG.rst
@@ -1,0 +1,8 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package rosserial_tivac
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.0.1 (2015-11-12)
+------------------
+* Initial package
+* Contributor: Vitor Matos

--- a/rosserial_tivac/CMakeLists.txt
+++ b/rosserial_tivac/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(rosserial_tivac)
+
+find_package(catkin REQUIRED)
+
+catkin_package(
+  CFG_EXTRAS rosserial_tivac-extras.cmake
+)
+
+install(
+  DIRECTORY
+    src/ros_lib
+    src/ros_lib_energia
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/src
+)
+
+install(
+  DIRECTORY tivac-cmake
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+install(
+  PROGRAMS 
+    src/rosserial_tivac/make_libraries
+    src/rosserial_tivac/make_libraries.py
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/rosserial_tivac/CMakeLists.txt
+++ b/rosserial_tivac/CMakeLists.txt
@@ -21,7 +21,7 @@ install(
 
 install(
   PROGRAMS 
-    src/rosserial_tivac/make_libraries
-    src/rosserial_tivac/make_libraries.py
+    src/rosserial_tivac/make_libraries_tiva
+    src/rosserial_tivac/make_libraries_energia
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/rosserial_tivac/cmake/rosserial_tivac-extras.cmake.em
+++ b/rosserial_tivac/cmake/rosserial_tivac-extras.cmake.em
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 2.8.3)
+
+@[if DEVELSPACE]@
+set(ROSSERIAL_TIVAC_TOOLCHAIN "@(CMAKE_CURRENT_SOURCE_DIR)/tivac-cmake/cmake/TivaCToolchain.cmake")
+@[else]@
+set(ROSSERIAL_TIVAC_TOOLCHAIN "${rosserial_tivac_DIR}/../tivac-cmake/cmake/TivaCToolchain.cmake")
+@[end if]@

--- a/rosserial_tivac/package.xml
+++ b/rosserial_tivac/package.xml
@@ -1,0 +1,27 @@
+<package>
+  <name>rosserial_tivac</name>
+  <version>0.0.1</version>
+  <description>
+  rosserial_tivac package provides the required hardware definitions for compiling rosserial_client targets for TivaC Launchpad 
+  evaluation boards.
+  </description>
+  <maintainer email="vmatos@robosavvy.com">Vitor Matos</maintainer>
+  <license>BSD</license>
+  <url type="website">http://wiki.ros.org/rosserial_tivac</url>
+  <url type="repository">https://github.com/robosavvy/rosserial</url>
+  <author>Vitor Matos</author>
+  <author email="vmatos@robosavvy.com">Vitor Matos</author>
+  
+  
+  <maintainer email="vmatos.pt@gmail.com">Vitor Matos</maintainer>
+  <license>BSD</license>
+  <url>http://ros.org/wiki/rosserial_tivac</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <run_depend>rospy</run_depend>
+  <run_depend>rosserial_msgs</run_depend>
+  <run_depend>rosserial_client</run_depend>
+</package>
+
+

--- a/rosserial_tivac/package.xml
+++ b/rosserial_tivac/package.xml
@@ -8,18 +8,12 @@
   <maintainer email="vmatos@robosavvy.com">Vitor Matos</maintainer>
   <license>BSD</license>
   <url type="website">http://wiki.ros.org/rosserial_tivac</url>
-  <url type="repository">https://github.com/robosavvy/rosserial</url>
+  <url type="repository">https://github.com/ros-drivers/rosserial</url>
   <author>Vitor Matos</author>
   <author email="vmatos@robosavvy.com">Vitor Matos</author>
-  
-  
-  <maintainer email="vmatos.pt@gmail.com">Vitor Matos</maintainer>
-  <license>BSD</license>
-  <url>http://ros.org/wiki/rosserial_tivac</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-
-  <run_depend>rospy</run_depend>
+  
   <run_depend>rosserial_msgs</run_depend>
   <run_depend>rosserial_client</run_depend>
 </package>

--- a/rosserial_tivac/src/ros_lib/ros.h
+++ b/rosserial_tivac/src/ros_lib/ros.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2015, Robosavvy Ltd.
+ * All rights reserved.
+ * Author: Vitor Matos
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the 
+ * following conditions are met:
+ * 
+ *   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the 
+ * following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the 
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote 
+ * products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED 
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ROSSERIAL_TIVAC_SRC_ROS_LIB_ROS_H
+#define ROSSERIAL_TIVAC_SRC_ROS_LIB_ROS_H
+
+#include <ros/node_handle.h>
+
+#ifdef USE_USBCON
+#include <tivac_hardware_usb.h>
+#else
+#include <tivac_hardware.h>
+#endif
+
+namespace ros
+{
+  /*!
+   int MAX_SUBSCRIBERS=25,
+   int MAX_PUBLISHERS=25,
+   int INPUT_SIZE=512,
+   int OUTPUT_SIZE=512
+  */
+  typedef NodeHandle_<TivaCHardware> NodeHandle;
+}
+#endif  // ROSSERIAL_TIVAC_SRC_ROS_LIB_ROS_H

--- a/rosserial_tivac/src/ros_lib/startup_gcc.c
+++ b/rosserial_tivac/src/ros_lib/startup_gcc.c
@@ -1,0 +1,490 @@
+/*
+ * Copyright (c) 2015, Robosavvy Ltd.
+ * All rights reserved.
+ * Author: Vitor Matos
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the 
+ * following conditions are met:
+ * 
+ *   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the 
+ * following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the 
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote 
+ * products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED 
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include "inc/hw_nvic.h"
+#include "inc/hw_types.h"
+
+//*****************************************************************************
+//
+// Forward declaration of the default fault handlers.
+//
+//*****************************************************************************
+void ResetISR(void);
+static void NmiSR(void);
+static void FaultISR(void);
+static void IntDefaultHandler(void);
+
+//*****************************************************************************
+//
+// The entry point for the application.
+//
+//*****************************************************************************
+extern int main(void);
+
+//*****************************************************************************
+// System stack start determined by ldscript, normally highest ram address
+//*****************************************************************************
+extern uint32_t _estack;
+
+//*****************************************************************************
+//
+// The vector table.  Note that the proper constructs must be placed on this to
+// ensure that it ends up at physical address 0x0000.0000.
+//
+//*****************************************************************************
+#ifdef TARGET_IS_TM4C123_RA1
+__attribute__ ((section(".isr_vector")))
+void (* const g_pfnVectors[])(void) =
+{
+    (void (*)(void))((uint32_t)&_estack),   // The initial stack pointer, 0x20008000 32K
+    ResetISR,                               // The reset handler
+    NmiSR,                                  // The NMI handler
+    FaultISR,                               // The hard fault handler
+    IntDefaultHandler,                      // The MPU fault handler
+    IntDefaultHandler,                      // The bus fault handler
+    IntDefaultHandler,                      // The usage fault handler
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    IntDefaultHandler,                      // SVCall handler
+    IntDefaultHandler,                      // Debug monitor handler
+    0,                                      // Reserved
+    IntDefaultHandler,                      // The PendSV handler
+    IntDefaultHandler,                      // The SysTick handler
+    IntDefaultHandler,                      // GPIO Port A
+    IntDefaultHandler,                      // GPIO Port B
+    IntDefaultHandler,                      // GPIO Port C
+    IntDefaultHandler,                      // GPIO Port D
+    IntDefaultHandler,                      // GPIO Port E
+    IntDefaultHandler,                      // UART0 Rx and Tx
+    IntDefaultHandler,                      // UART1 Rx and Tx
+    IntDefaultHandler,                      // SSI0 Rx and Tx
+    IntDefaultHandler,                      // I2C0 Master and Slave
+    IntDefaultHandler,                      // PWM Fault
+    IntDefaultHandler,                      // PWM Generator 0
+    IntDefaultHandler,                      // PWM Generator 1
+    IntDefaultHandler,                      // PWM Generator 2
+    IntDefaultHandler,                      // Quadrature Encoder 0
+    IntDefaultHandler,                      // ADC Sequence 0
+    IntDefaultHandler,                      // ADC Sequence 1
+    IntDefaultHandler,                      // ADC Sequence 2
+    IntDefaultHandler,                      // ADC Sequence 3
+    IntDefaultHandler,                      // Watchdog timer
+    IntDefaultHandler,                      // Timer 0 subtimer A
+    IntDefaultHandler,                      // Timer 0 subtimer B
+    IntDefaultHandler,                      // Timer 1 subtimer A
+    IntDefaultHandler,                      // Timer 1 subtimer B
+    IntDefaultHandler,                      // Timer 2 subtimer A
+    IntDefaultHandler,                      // Timer 2 subtimer B
+    IntDefaultHandler,                      // Analog Comparator 0
+    IntDefaultHandler,                      // Analog Comparator 1
+    IntDefaultHandler,                      // Analog Comparator 2
+    IntDefaultHandler,                      // System Control (PLL, OSC, BO)
+    IntDefaultHandler,                      // FLASH Control
+    IntDefaultHandler,                      // GPIO Port F
+    IntDefaultHandler,                      // GPIO Port G
+    IntDefaultHandler,                      // GPIO Port H
+    IntDefaultHandler,                      // UART2 Rx and Tx
+    IntDefaultHandler,                      // SSI1 Rx and Tx
+    IntDefaultHandler,                      // Timer 3 subtimer A
+    IntDefaultHandler,                      // Timer 3 subtimer B
+    IntDefaultHandler,                      // I2C1 Master and Slave
+    IntDefaultHandler,                      // Quadrature Encoder 1
+    IntDefaultHandler,                      // CAN0
+    IntDefaultHandler,                      // CAN1
+    0,                                      // Reserved
+    0,                                      // Reserved
+    IntDefaultHandler,                      // Hibernate
+    IntDefaultHandler,                      // USB0
+    IntDefaultHandler,                      // PWM Generator 3
+    IntDefaultHandler,                      // uDMA Software Transfer
+    IntDefaultHandler,                      // uDMA Error
+    IntDefaultHandler,                      // ADC1 Sequence 0
+    IntDefaultHandler,                      // ADC1 Sequence 1
+    IntDefaultHandler,                      // ADC1 Sequence 2
+    IntDefaultHandler,                      // ADC1 Sequence 3
+    0,                                      // Reserved
+    0,                                      // Reserved
+    IntDefaultHandler,                      // GPIO Port J
+    IntDefaultHandler,                      // GPIO Port K
+    IntDefaultHandler,                      // GPIO Port L
+    IntDefaultHandler,                      // SSI2 Rx and Tx
+    IntDefaultHandler,                      // SSI3 Rx and Tx
+    IntDefaultHandler,                      // UART3 Rx and Tx
+    IntDefaultHandler,                      // UART4 Rx and Tx
+    IntDefaultHandler,                      // UART5 Rx and Tx
+    IntDefaultHandler,                      // UART6 Rx and Tx
+    IntDefaultHandler,                      // UART7 Rx and Tx
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    IntDefaultHandler,                      // I2C2 Master and Slave
+    IntDefaultHandler,                      // I2C3 Master and Slave
+    IntDefaultHandler,                      // Timer 4 subtimer A
+    IntDefaultHandler,                      // Timer 4 subtimer B
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    IntDefaultHandler,                      // Timer 5 subtimer A
+    IntDefaultHandler,                      // Timer 5 subtimer B
+    IntDefaultHandler,                      // Wide Timer 0 subtimer A
+    IntDefaultHandler,                      // Wide Timer 0 subtimer B
+    IntDefaultHandler,                      // Wide Timer 1 subtimer A
+    IntDefaultHandler,                      // Wide Timer 1 subtimer B
+    IntDefaultHandler,                      // Wide Timer 2 subtimer A
+    IntDefaultHandler,                      // Wide Timer 2 subtimer B
+    IntDefaultHandler,                      // Wide Timer 3 subtimer A
+    IntDefaultHandler,                      // Wide Timer 3 subtimer B
+    IntDefaultHandler,                      // Wide Timer 4 subtimer A
+    IntDefaultHandler,                      // Wide Timer 4 subtimer B
+    IntDefaultHandler,                      // Wide Timer 5 subtimer A
+    IntDefaultHandler,                      // Wide Timer 5 subtimer B
+    IntDefaultHandler,                      // FPU
+    0,                                      // Reserved
+    0,                                      // Reserved
+    IntDefaultHandler,                      // I2C4 Master and Slave
+    IntDefaultHandler,                      // I2C5 Master and Slave
+    IntDefaultHandler,                      // GPIO Port M
+    IntDefaultHandler,                      // GPIO Port N
+    IntDefaultHandler,                      // Quadrature Encoder 2
+    0,                                      // Reserved
+    0,                                      // Reserved
+    IntDefaultHandler,                      // GPIO Port P (Summary or P0)
+    IntDefaultHandler,                      // GPIO Port P1
+    IntDefaultHandler,                      // GPIO Port P2
+    IntDefaultHandler,                      // GPIO Port P3
+    IntDefaultHandler,                      // GPIO Port P4
+    IntDefaultHandler,                      // GPIO Port P5
+    IntDefaultHandler,                      // GPIO Port P6
+    IntDefaultHandler,                      // GPIO Port P7
+    IntDefaultHandler,                      // GPIO Port Q (Summary or Q0)
+    IntDefaultHandler,                      // GPIO Port Q1
+    IntDefaultHandler,                      // GPIO Port Q2
+    IntDefaultHandler,                      // GPIO Port Q3
+    IntDefaultHandler,                      // GPIO Port Q4
+    IntDefaultHandler,                      // GPIO Port Q5
+    IntDefaultHandler,                      // GPIO Port Q6
+    IntDefaultHandler,                      // GPIO Port Q7
+    IntDefaultHandler,                      // GPIO Port R
+    IntDefaultHandler,                      // GPIO Port S
+    IntDefaultHandler,                      // PWM 1 Generator 0
+    IntDefaultHandler,                      // PWM 1 Generator 1
+    IntDefaultHandler,                      // PWM 1 Generator 2
+    IntDefaultHandler,                      // PWM 1 Generator 3
+    IntDefaultHandler                       // PWM 1 Fault
+};
+#endif
+#ifdef TARGET_IS_TM4C129_RA0
+__attribute__ ((section(".isr_vector")))
+void (* const g_pfnVectors[])(void) =
+{
+    (void (*)(void))((uint32_t)&_estack),   // The initial stack pointer
+    ResetISR,                               // The reset handler
+    NmiSR,                                  // The NMI handler
+    FaultISR,                               // The hard fault handler
+    IntDefaultHandler,                      // The MPU fault handler
+    IntDefaultHandler,                      // The bus fault handler
+    IntDefaultHandler,                      // The usage fault handler
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    0,                                      // Reserved
+    IntDefaultHandler,                      // SVCall handler
+    IntDefaultHandler,                      // Debug monitor handler
+    0,                                      // Reserved
+    IntDefaultHandler,                      // The PendSV handler
+    IntDefaultHandler,                      // The SysTick handler
+    IntDefaultHandler,                      // GPIO Port A
+    IntDefaultHandler,                      // GPIO Port B
+    IntDefaultHandler,                      // GPIO Port C
+    IntDefaultHandler,                      // GPIO Port D
+    IntDefaultHandler,                      // GPIO Port E
+    IntDefaultHandler,                      // UART0 Rx and Tx
+    IntDefaultHandler,                      // UART1 Rx and Tx
+    IntDefaultHandler,                      // SSI0 Rx and Tx
+    IntDefaultHandler,                      // I2C0 Master and Slave
+    IntDefaultHandler,                      // PWM Fault
+    IntDefaultHandler,                      // PWM Generator 0
+    IntDefaultHandler,                      // PWM Generator 1
+    IntDefaultHandler,                      // PWM Generator 2
+    IntDefaultHandler,                      // Quadrature Encoder 0
+    IntDefaultHandler,                      // ADC Sequence 0
+    IntDefaultHandler,                      // ADC Sequence 1
+    IntDefaultHandler,                      // ADC Sequence 2
+    IntDefaultHandler,                      // ADC Sequence 3
+    IntDefaultHandler,                      // Watchdog timer
+    IntDefaultHandler,                      // Timer 0 subtimer A
+    IntDefaultHandler,                      // Timer 0 subtimer B
+    IntDefaultHandler,                      // Timer 1 subtimer A
+    IntDefaultHandler,                      // Timer 1 subtimer B
+    IntDefaultHandler,                      // Timer 2 subtimer A
+    IntDefaultHandler,                      // Timer 2 subtimer B
+    IntDefaultHandler,                      // Analog Comparator 0
+    IntDefaultHandler,                      // Analog Comparator 1
+    IntDefaultHandler,                      // Analog Comparator 2
+    IntDefaultHandler,                      // System Control (PLL, OSC, BO)
+    IntDefaultHandler,                      // FLASH Control
+    IntDefaultHandler,                      // GPIO Port F
+    IntDefaultHandler,                      // GPIO Port G
+    IntDefaultHandler,                      // GPIO Port H
+    IntDefaultHandler,                      // UART2 Rx and Tx
+    IntDefaultHandler,                      // SSI1 Rx and Tx
+    IntDefaultHandler,                      // Timer 3 subtimer A
+    IntDefaultHandler,                      // Timer 3 subtimer B
+    IntDefaultHandler,                      // I2C1 Master and Slave
+    IntDefaultHandler,                      // CAN0
+    IntDefaultHandler,                      // CAN1
+    IntDefaultHandler,                      // Ethernet
+    IntDefaultHandler,                      // Hibernate
+    IntDefaultHandler,                      // USB0
+    IntDefaultHandler,                      // PWM Generator 3
+    IntDefaultHandler,                      // uDMA Software Transfer
+    IntDefaultHandler,                      // uDMA Error
+    IntDefaultHandler,                      // ADC1 Sequence 0
+    IntDefaultHandler,                      // ADC1 Sequence 1
+    IntDefaultHandler,                      // ADC1 Sequence 2
+    IntDefaultHandler,                      // ADC1 Sequence 3
+    IntDefaultHandler,                      // External Bus Interface 0
+    IntDefaultHandler,                      // GPIO Port J
+    IntDefaultHandler,                      // GPIO Port K
+    IntDefaultHandler,                      // GPIO Port L
+    IntDefaultHandler,                      // SSI2 Rx and Tx
+    IntDefaultHandler,                      // SSI3 Rx and Tx
+    IntDefaultHandler,                      // UART3 Rx and Tx
+    IntDefaultHandler,                      // UART4 Rx and Tx
+    IntDefaultHandler,                      // UART5 Rx and Tx
+    IntDefaultHandler,                      // UART6 Rx and Tx
+    IntDefaultHandler,                      // UART7 Rx and Tx
+    IntDefaultHandler,                      // I2C2 Master and Slave
+    IntDefaultHandler,                      // I2C3 Master and Slave
+    IntDefaultHandler,                      // Timer 4 subtimer A
+    IntDefaultHandler,                      // Timer 4 subtimer B
+    IntDefaultHandler,                      // Timer 5 subtimer A
+    IntDefaultHandler,                      // Timer 5 subtimer B
+    IntDefaultHandler,                      // FPU
+    0,                                      // Reserved
+    0,                                      // Reserved
+    IntDefaultHandler,                      // I2C4 Master and Slave
+    IntDefaultHandler,                      // I2C5 Master and Slave
+    IntDefaultHandler,                      // GPIO Port M
+    IntDefaultHandler,                      // GPIO Port N
+    0,                                      // Reserved
+    IntDefaultHandler,                      // Tamper
+    IntDefaultHandler,                      // GPIO Port P (Summary or P0)
+    IntDefaultHandler,                      // GPIO Port P1
+    IntDefaultHandler,                      // GPIO Port P2
+    IntDefaultHandler,                      // GPIO Port P3
+    IntDefaultHandler,                      // GPIO Port P4
+    IntDefaultHandler,                      // GPIO Port P5
+    IntDefaultHandler,                      // GPIO Port P6
+    IntDefaultHandler,                      // GPIO Port P7
+    IntDefaultHandler,                      // GPIO Port Q (Summary or Q0)
+    IntDefaultHandler,                      // GPIO Port Q1
+    IntDefaultHandler,                      // GPIO Port Q2
+    IntDefaultHandler,                      // GPIO Port Q3
+    IntDefaultHandler,                      // GPIO Port Q4
+    IntDefaultHandler,                      // GPIO Port Q5
+    IntDefaultHandler,                      // GPIO Port Q6
+    IntDefaultHandler,                      // GPIO Port Q7
+    IntDefaultHandler,                      // GPIO Port R
+    IntDefaultHandler,                      // GPIO Port S
+    IntDefaultHandler,                      // SHA/MD5 0
+    IntDefaultHandler,                      // AES 0
+    IntDefaultHandler,                      // DES3DES 0
+    IntDefaultHandler,                      // LCD Controller 0
+    IntDefaultHandler,                      // Timer 6 subtimer A
+    IntDefaultHandler,                      // Timer 6 subtimer B
+    IntDefaultHandler,                      // Timer 7 subtimer A
+    IntDefaultHandler,                      // Timer 7 subtimer B
+    IntDefaultHandler,                      // I2C6 Master and Slave
+    IntDefaultHandler,                      // I2C7 Master and Slave
+    IntDefaultHandler,                      // HIM Scan Matrix Keyboard 0
+    IntDefaultHandler,                      // One Wire 0
+    IntDefaultHandler,                      // HIM PS/2 0
+    IntDefaultHandler,                      // HIM LED Sequencer 0
+    IntDefaultHandler,                      // HIM Consumer IR 0
+    IntDefaultHandler,                      // I2C8 Master and Slave
+    IntDefaultHandler,                      // I2C9 Master and Slave
+    IntDefaultHandler                       // GPIO Port T
+};
+#endif
+
+//*****************************************************************************
+//
+// The following are constructs created by the linker, indicating where the
+// the "data" and "bss" segments reside in memory.  The initializers for the
+// for the "data" segment resides immediately following the "text" segment.
+//
+//*****************************************************************************
+extern uint32_t _etext;
+extern uint32_t _data;
+extern uint32_t _edata;
+extern uint32_t _bss;
+extern uint32_t _ebss;
+extern void (*__preinit_array_start[])(void);
+extern void (*__preinit_array_end[])(void);
+extern void (*__init_array_start[])(void);
+extern void (*__init_array_end[])(void);
+
+//*****************************************************************************
+//
+// This is the code that gets called when the processor first starts execution
+// following a reset event.  Only the absolutely necessary set is performed,
+// after which the application supplied entry() routine is called.  Any fancy
+// actions (such as making decisions based on the reset cause register, and
+// resetting the bits in that register) are left solely in the hands of the
+// application.
+//
+//*****************************************************************************
+void
+ResetISR(void)
+{
+    uint32_t *pui32Src, *pui32Dest;
+    uint32_t i, cnt;
+    
+    //
+    // Copy the data segment initializers from flash to SRAM.
+    //
+    pui32Src = &_etext;
+    for(pui32Dest = &_data; pui32Dest < &_edata; )
+    {
+        *pui32Dest++ = *pui32Src++;
+    }
+
+    //
+    // Zero fill the bss segment.
+    //
+    __asm("    ldr     r0, =_bss\n"
+          "    ldr     r1, =_ebss\n"
+          "    mov     r2, #0\n"
+          "    .thumb_func\n"
+          "zero_loop:\n"
+          "        cmp     r0, r1\n"
+          "        it      lt\n"
+          "        strlt   r2, [r0], #4\n"
+          "        blt     zero_loop");
+
+    //
+    // Enable the floating-point unit.  This must be done here to handle the
+    // case where main() uses floating-point and the function prologue saves
+    // floating-point registers (which will fault if floating-point is not
+    // enabled).  Any configuration of the floating-point unit using DriverLib
+    // APIs must be done here prior to the floating-point unit being enabled.
+    //
+    HWREG(NVIC_CPAC) = ((HWREG(NVIC_CPAC) &
+                         ~(NVIC_CPAC_CP10_M | NVIC_CPAC_CP11_M)) |
+                        NVIC_CPAC_CP10_FULL | NVIC_CPAC_CP11_FULL);
+                        
+    //
+    // call any global c++ ctors
+    //
+    cnt = __preinit_array_end - __preinit_array_start;
+    for (i = 0; i < cnt; i++)
+        __preinit_array_start[i]();
+    cnt = __init_array_end - __init_array_start;
+    for (i = 0; i < cnt; i++)
+        __init_array_start[i]();
+        
+    //
+    // Call the application's entry point.
+    //
+    main();
+}
+
+//*****************************************************************************
+//
+// This is the code that gets called when the processor receives a NMI.  This
+// simply enters an infinite loop, preserving the system state for examination
+// by a debugger.
+//
+//*****************************************************************************
+static void
+NmiSR(void)
+{
+    //
+    // Enter an infinite loop.
+    //
+    while(1)
+    {
+    }
+}
+
+//*****************************************************************************
+//
+// This is the code that gets called when the processor receives a fault
+// interrupt.  This simply enters an infinite loop, preserving the system state
+// for examination by a debugger.
+//
+//*****************************************************************************
+static void
+FaultISR(void)
+{
+    //
+    // Enter an infinite loop.
+    //
+    while(1)
+    {
+    }
+}
+
+//*****************************************************************************
+//
+// This is the code that gets called when the processor receives an unexpected
+// interrupt.  This simply enters an infinite loop, preserving the system state
+// for examination by a debugger.
+//
+//*****************************************************************************
+static void
+IntDefaultHandler(void)
+{
+    //
+    // Go into an infinite loop.
+    //
+    while(1)
+    {
+    }
+}
+
+/* syscall stuff */
+void *__dso_handle = 0;

--- a/rosserial_tivac/src/ros_lib/startup_gcc.c
+++ b/rosserial_tivac/src/ros_lib/startup_gcc.c
@@ -1,26 +1,39 @@
-/*
- * Copyright (c) 2015, Robosavvy Ltd.
- * All rights reserved.
- * Author: Vitor Matos
- * 
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the 
- * following conditions are met:
- * 
- *   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the 
- * following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the 
- * following disclaimer in the documentation and/or other materials provided with the distribution.
- *   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED 
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
- * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
- * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+//*****************************************************************************
+//
+// startup_gcc.c - Startup code for use with GNU tools.
+//
+// Copyright (c) 2009-2012 Texas Instruments Incorporated.  All rights reserved.
+// Software License Agreement
+// 
+//   Redistribution and use in source and binary forms, with or without
+//   modification, are permitted provided that the following conditions
+//   are met:
+// 
+//   Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+// 
+//   Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the  
+//   distribution.
+// 
+//   Neither the name of Texas Instruments Incorporated nor the names of
+//   its contributors may be used to endorse or promote products derived
+//   from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//*****************************************************************************
 
 #include <stdint.h>
 #include "inc/hw_nvic.h"

--- a/rosserial_tivac/src/ros_lib/tivac_hardware.h
+++ b/rosserial_tivac/src/ros_lib/tivac_hardware.h
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2015, Robosavvy Ltd.
+ * All rights reserved.
+ * Author: Vitor Matos
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the 
+ * following conditions are met:
+ * 
+ *   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the 
+ * following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the 
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote 
+ * products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED 
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+//*****************************************************************************
+//
+// Bare minimum hardware resources allocated for rosserials communication.
+// * 2 LEDs if desired
+// * One UART port, interrupt driven transfers
+// * Two RingBuffers of TX_BUFFER_SIZE and RX_BUFFER_SIZE
+// * Systick Interrupt handler
+//
+//*****************************************************************************
+
+#ifndef ROS_LIB_TIVAC_HARDWARE_H
+#define ROS_LIB_TIVAC_HARDWARE_H
+
+extern "C"
+{
+  #include <inc/hw_memmap.h>
+  #include <inc/hw_ints.h>
+  #include <driverlib/gpio.h>
+  #include <driverlib/rom.h>
+  #include <driverlib/rom_map.h>
+  #include <driverlib/systick.h>
+  #include <driverlib/pin_map.h>
+  #include <driverlib/uart.h>
+  #include <utils/ringbuf.h>
+}
+
+#define SYSTICKHZ  1000UL
+
+#ifdef TARGET_IS_TM4C123_RA1
+#define LED1        GPIO_PIN_3  // Green LED
+#define LED2        GPIO_PIN_2  // Blue LED
+#define LED_PORT    GPIO_PORTF_BASE
+#define LED_PERIPH  SYSCTL_PERIPH_GPIOF
+#endif
+
+#ifdef TARGET_IS_TM4C129_RA0
+#define LED1        GPIO_PIN_1  // D1 LED
+#define LED2        GPIO_PIN_0  // D2 LED
+#define LED_PORT    GPIO_PORTN_BASE
+#define LED_PERIPH  SYSCTL_PERIPH_GPION
+#ifndef TM4C129FREQ
+#error "Must define system clock frequency on: TM4C129FREQ"
+#endif
+#endif
+
+#ifndef ROSSERIAL_BAUDRATE
+#define ROSSERIAL_BAUDRATE 57600
+#endif
+
+class TivaCHardware
+{
+  public:
+    TivaCHardware() {}
+
+    void init()
+    {
+#ifdef TARGET_IS_TM4C123_RA1
+      TivaCHardware::ui32SysClkFreq = MAP_SysCtlClockGet();
+#endif
+#ifdef TARGET_IS_TM4C129_RA0
+      TivaCHardware::ui32SysClkFreq = TM4C129FREQ;
+#endif
+
+      // Setup LEDs
+#if defined(LED_HEARTBEAT) || defined(LED_COMM)
+      MAP_SysCtlPeripheralEnable(LED_PERIPH);
+#endif
+#ifdef LED_HEARTBEAT
+      MAP_GPIOPinTypeGPIOOutput(LED_PORT, LED1);
+#endif
+#ifdef LED_COMM
+      MAP_GPIOPinTypeGPIOOutput(LED_PORT, LED2);
+#endif
+
+      // Enable time keeping
+      TivaCHardware::milliseconds = 0;
+      // Set up timer such that it produces one tick for each millisecond
+      SysTickIntRegister(TivaCHardware::SystickIntHandler);
+      MAP_SysTickPeriodSet(TivaCHardware::ui32SysClkFreq/SYSTICKHZ);
+      MAP_SysTickEnable();
+      MAP_SysTickIntEnable();
+
+      // Enable the peripherals for UART0
+      MAP_SysCtlPeripheralEnable(SYSCTL_PERIPH_UART0);
+      MAP_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOA);
+      // Set GPIO A0 and A1 as UART pins.
+      MAP_GPIOPinConfigure(GPIO_PA0_U0RX);
+      MAP_GPIOPinConfigure(GPIO_PA1_U0TX);
+      MAP_GPIOPinTypeUART(GPIO_PORTA_BASE, GPIO_PIN_0 | GPIO_PIN_1);
+      // Configure UART0
+      MAP_UARTConfigSetExpClk(UART0_BASE, TivaCHardware::ui32SysClkFreq, ROSSERIAL_BAUDRATE,
+          (UART_CONFIG_WLEN_8 | UART_CONFIG_STOP_ONE | UART_CONFIG_PAR_NONE));
+      // Supposedely MCU resets with FIFO 1 byte depth. Just making sure.
+      MAP_UARTFIFODisable(UART0_BASE);
+      // UART buffers to transmit and receive
+      RingBufInit(&TivaCHardware::rxBuffer, this->ui8rxBufferData, RX_BUFFER_SIZE);
+      RingBufInit(&TivaCHardware::txBuffer, this->ui8txBufferData, TX_BUFFER_SIZE);
+
+      // Enable RX and TX interrupt
+      UARTIntRegister(UART0_BASE, TivaCHardware::UARTIntHandler);
+      MAP_IntEnable(INT_UART0);
+      MAP_UARTTxIntModeSet(UART0_BASE, UART_TXINT_MODE_EOT);
+      MAP_UARTIntEnable(UART0_BASE, UART_INT_RX | UART_INT_TX);
+
+      // Enable processor interrupts.
+      MAP_IntMasterEnable();
+    }
+
+    // read a byte from the serial port. -1 = failure
+    int read()
+    {
+      if (!RingBufEmpty(&TivaCHardware::rxBuffer))
+        return RingBufReadOne(&TivaCHardware::rxBuffer);
+      else
+        return -1;
+    }
+
+    // write data to the connection to ROS
+    void write(uint8_t* data, int length)
+    {
+      RingBufWrite(&txBuffer, data, length);
+      // Trigger sending buffer
+      MAP_UARTCharPutNonBlocking(UART0_BASE, RingBufReadOne(&TivaCHardware::txBuffer));
+    }
+
+    // returns milliseconds since start of program
+    uint32_t time()
+    {
+      return TivaCHardware::milliseconds;
+    }
+
+    // UART buffer structures
+    static tRingBufObject rxBuffer;
+    uint8_t ui8rxBufferData[RX_BUFFER_SIZE];
+    static tRingBufObject txBuffer;
+    uint8_t ui8txBufferData[TX_BUFFER_SIZE];
+    // UARD interrupt handler
+    // For each received byte, pushes it into the buffer.
+    // For each transmitted byte, read the next available from the buffer.
+    static void UARTIntHandler()
+    {
+      uint32_t ui32Status;
+      // Get the interrrupt status.
+      ui32Status = MAP_UARTIntStatus(UART0_BASE, true);
+      // Clear the asserted interrupts.
+      MAP_UARTIntClear(UART0_BASE, ui32Status);
+
+      // Since we are using no RX, or TX FIFO, only one char at a time for each interrupt call
+      // RX the next character from the UART and put it on RingBuffer.
+      // We should verify if buffer is not full. Let's assume not, for faster interrupt routine.
+      if (ui32Status & UART_INT_RX)
+        RingBufWriteOne(&TivaCHardware::rxBuffer, MAP_UARTCharGetNonBlocking(UART0_BASE));
+
+      // TX the next available char on the buffer
+      if (ui32Status & UART_INT_TX)
+        if (!RingBufEmpty(&TivaCHardware::txBuffer))
+          MAP_UARTCharPutNonBlocking(UART0_BASE, RingBufReadOne(&TivaCHardware::txBuffer));
+
+#ifdef LED_COMM
+      // Blink the LED to show a character transfer is occuring.
+      MAP_GPIOPinWrite(LED_PORT, LED2, MAP_GPIOPinRead(LED_PORT, LED2)^LED2);
+#endif
+    }
+
+    // Timing variables and System Tick interrupt handler.
+    static volatile uint32_t milliseconds;
+    static volatile uint32_t heartbeat;
+    static void SystickIntHandler()
+    {
+      ++TivaCHardware::milliseconds;
+#ifdef LED_HEARTBEAT
+      if (++TivaCHardware::heartbeat >= SYSTICKHZ)
+      {
+        MAP_GPIOPinWrite(LED_PORT, LED1, MAP_GPIOPinRead(LED_PORT, LED1)^LED1);
+        TivaCHardware::heartbeat = 0;
+      }
+#endif
+    }
+
+    static uint32_t ui32SysClkFreq;
+};
+
+// Static class members
+volatile uint32_t TivaCHardware::milliseconds = 0;
+volatile uint32_t TivaCHardware::heartbeat = 0;
+uint32_t TivaCHardware::ui32SysClkFreq;
+tRingBufObject TivaCHardware::rxBuffer;
+tRingBufObject TivaCHardware::txBuffer;
+
+// Not really accurate ms delay. But good enough for our purposes.
+// For a more elaborate delay check out ``Energia/hardware/lm4f/cores/lm4f/wiring.c``
+void delay(uint32_t ms)
+{
+  while (ms > 500)
+  {
+    MAP_SysCtlDelay(TivaCHardware::ui32SysClkFreq/3/SYSTICKHZ * 500);
+    ms -= 500;
+  }
+  MAP_SysCtlDelay(TivaCHardware::ui32SysClkFreq/3/SYSTICKHZ * ms);
+}
+
+#endif  // ROS_LIB_TIVAC_HARDWARE_H

--- a/rosserial_tivac/src/ros_lib/tivac_hardware_usb.h
+++ b/rosserial_tivac/src/ros_lib/tivac_hardware_usb.h
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2015, Robosavvy Ltd.
+ * All rights reserved.
+ * Author: Vitor Matos
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the 
+ * following conditions are met:
+ * 
+ *   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the 
+ * following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the 
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote 
+ * products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED 
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+//*****************************************************************************
+//
+// Bare minimum hardware resources allocated for rosserials communication.
+// * 2 LEDs if desired
+// * One USB port
+// * Two USBBuffers of UART_BUFFER_SIZE
+// * Systick Interrupt handler
+//
+//*****************************************************************************
+
+#ifndef ROS_LIB_TIVAC_HARDWARE_USB_H
+#define ROS_LIB_TIVAC_HARDWARE_USB_H
+
+extern "C"
+{
+  #include <inc/hw_memmap.h>
+  #include <inc/hw_ints.h>
+  #include <driverlib/gpio.h>
+  #include <driverlib/rom.h>
+  #include <driverlib/rom_map.h>
+  #include <driverlib/systick.h>
+  #include <driverlib/pin_map.h>
+  #include <driverlib/usb.h>
+  #include <usblib/usblib.h>
+  #include <usblib/usbcdc.h>
+  #include <usblib/usb-ids.h>
+  #include <usblib/device/usbdevice.h>
+  #include <usblib/device/usbdcdc.h>
+  #include "usb_serial_structs.h"
+}
+
+#define SYSTICKHZ  1000UL
+
+#ifdef TARGET_IS_TM4C123_RA1
+#define LED1        GPIO_PIN_3  // Green LED
+#define LED2        GPIO_PIN_2  // Blue LED
+#define LED_PORT    GPIO_PORTF_BASE
+#define LED_PERIPH  SYSCTL_PERIPH_GPIOF
+#endif
+
+#ifdef TARGET_IS_TM4C129_RA0
+#define LED1        GPIO_PIN_1  // D1 LED
+#define LED2        GPIO_PIN_0  // D2 LED
+#define LED_PORT    GPIO_PORTN_BASE
+#define LED_PERIPH  SYSCTL_PERIPH_GPION
+#ifndef TM4C129FREQ
+#error "Must define system clock frequency on: TM4C129FREQ"
+#endif
+#endif
+
+class TivaCHardware
+{
+  public:
+    TivaCHardware() {}
+
+    void init()
+    {
+#ifdef TARGET_IS_TM4C123_RA1
+      TivaCHardware::ui32SysClkFreq = MAP_SysCtlClockGet();
+#endif
+#ifdef TARGET_IS_TM4C129_RA0
+      TivaCHardware::ui32SysClkFreq = TM4C129FREQ;
+#endif
+
+      // Setup LEDs
+#if defined(LED_HEARTBEAT) || defined(LED_COMM)
+      MAP_SysCtlPeripheralEnable(LED_PERIPH);
+#endif
+#ifdef LED_HEARTBEAT
+      MAP_GPIOPinTypeGPIOOutput(LED_PORT, LED1);
+#endif
+#ifdef LED_COMM
+      MAP_GPIOPinTypeGPIOOutput(LED_PORT, LED2);
+#endif
+
+      // Enable time keeping
+      TivaCHardware::milliseconds = 0;
+      // Set up timer such that it produces one tick for each millisecond
+      SysTickIntRegister(TivaCHardware::SystickIntHandler);
+      MAP_SysTickPeriodSet(TivaCHardware::ui32SysClkFreq/SYSTICKHZ);
+      MAP_SysTickEnable();
+      MAP_SysTickIntEnable();
+
+      MAP_SysCtlPeripheralEnable(SYSCTL_PERIPH_USB0);
+#ifdef TARGET_IS_TM4C123_RA1
+      // Configure the required pins for USB operation.
+      MAP_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOD);
+      MAP_GPIOPinTypeUSBAnalog(GPIO_PORTD_BASE, GPIO_PIN_5 | GPIO_PIN_4);
+#endif
+#ifdef TARGET_IS_TM4C129_RA0
+      MAP_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOL);
+      MAP_GPIOPinTypeUSBAnalog(GPIO_PORTL_BASE, GPIO_PIN_6 | GPIO_PIN_7);
+#endif
+
+      // Initialize the transmit and receive buffers.
+      USBBufferInit(&g_sTxBuffer);
+      USBBufferInit(&g_sRxBuffer);
+
+      // Set the USB stack mode to Device mode with VBUS monitoring.
+      USBStackModeSet(0, eUSBModeForceDevice, 0);
+
+      // Pass our device information to the USB library and place the device
+      // on the bus.
+      USBDCDCInit(0, &g_sCDCDevice);
+
+      // Register USB interrupt handler
+      USBIntRegister(USB0_BASE, USB0DeviceIntHandler);
+
+      // Enable processor interrupts.
+      MAP_IntMasterEnable();
+    }
+
+    // read a byte from the serial port. -1 = failure
+    int read()
+    {
+      uint8_t ui8ReadData;
+      if (USBBufferRead(&g_sRxBuffer, &ui8ReadData, 1) == 1)
+      {
+#ifdef LED_COMM
+        // Blink the LED to show a character transfer is occuring.
+        MAP_GPIOPinWrite(LED_PORT, LED2, MAP_GPIOPinRead(LED_PORT, LED2)^LED2);
+#endif
+        return ui8ReadData;
+      }
+      else
+        return -1;
+    }
+
+    // write data to the connection to ROS
+    void write(uint8_t* data, int length)
+    {
+#ifdef LED_COMM
+      // Blink the LED to show a character transfer is occuring.
+      MAP_GPIOPinWrite(LED_PORT, LED2, MAP_GPIOPinRead(LED_PORT, LED2)^LED2);
+#endif
+      // Let's assume for now all length is available for storage in the buffer.
+      // Otherwise must use: USBBufferSpaceAvailable
+      USBBufferWrite(&g_sTxBuffer, data, length);
+    }
+
+    // returns milliseconds since start of program
+    uint32_t time()
+    {
+      return TivaCHardware::milliseconds;
+    }
+
+    // Timing variables and System Tick interrupt handler.
+    static volatile uint32_t milliseconds;
+    static volatile uint32_t heartbeat;
+    static void SystickIntHandler()
+    {
+      ++TivaCHardware::milliseconds;
+#ifdef LED_HEARTBEAT
+      if (++TivaCHardware::heartbeat >= SYSTICKHZ)
+      {
+        MAP_GPIOPinWrite(LED_PORT, LED1, MAP_GPIOPinRead(LED_PORT, LED1)^LED1);
+        TivaCHardware::heartbeat = 0;
+      }
+#endif
+    }
+
+    static uint32_t ui32SysClkFreq;
+};
+
+// Static class members
+volatile uint32_t TivaCHardware::milliseconds = 0;
+volatile uint32_t TivaCHardware::heartbeat = 0;
+uint32_t TivaCHardware::ui32SysClkFreq;
+
+// Not really accurate ms delay. But good enough for our purposes.
+// For a more elaborate delay check out ``Energia/hardware/lm4f/cores/lm4f/wiring.c``
+void delay(uint32_t ms)
+{
+  while (ms > 500)
+  {
+    MAP_SysCtlDelay(TivaCHardware::ui32SysClkFreq/3/SYSTICKHZ * 500);
+    ms -= 500;
+  }
+  MAP_SysCtlDelay(TivaCHardware::ui32SysClkFreq/3/SYSTICKHZ * ms);
+}
+
+#endif  // ROS_LIB_TIVAC_HARDWARE_USB_H

--- a/rosserial_tivac/src/ros_lib/usb_serial_structs.c
+++ b/rosserial_tivac/src/ros_lib/usb_serial_structs.c
@@ -165,9 +165,6 @@ const uint8_t * const g_ppui8StringDescriptors[] =
 // function and the callback data set to our CDC instance structure.
 //
 //*****************************************************************************
-extern const tUSBBuffer g_sTxBuffer;
-extern const tUSBBuffer g_sRxBuffer;
-
 tUSBDCDCDevice g_sCDCDevice =
 {
     USB_VID_TI_1CBE,
@@ -190,8 +187,7 @@ tUSBDCDCDevice g_sCDCDevice =
 //
 //*****************************************************************************
 uint8_t g_pui8USBRxBuffer[UART_BUFFER_SIZE];
-uint8_t g_pui8RxBufferWorkspace[USB_BUFFER_WORKSPACE_SIZE];
-const tUSBBuffer g_sRxBuffer =
+tUSBBuffer g_sRxBuffer =
 {
     false,                          // This is a receive buffer.
     RxHandler,                      // pfnCallback
@@ -201,7 +197,6 @@ const tUSBBuffer g_sRxBuffer =
     (void *)&g_sCDCDevice,          // pvHandle
     g_pui8USBRxBuffer,              // pui8Buffer
     UART_BUFFER_SIZE,               // ui32BufferSize
-    g_pui8RxBufferWorkspace         // pvWorkspace
 };
 
 //*****************************************************************************
@@ -210,8 +205,7 @@ const tUSBBuffer g_sRxBuffer =
 //
 //*****************************************************************************
 uint8_t g_pui8USBTxBuffer[UART_BUFFER_SIZE];
-uint8_t g_pui8TxBufferWorkspace[USB_BUFFER_WORKSPACE_SIZE];
-const tUSBBuffer g_sTxBuffer =
+tUSBBuffer g_sTxBuffer =
 {
     true,                           // This is a transmit buffer.
     TxHandler,                      // pfnCallback
@@ -221,7 +215,6 @@ const tUSBBuffer g_sTxBuffer =
     (void *)&g_sCDCDevice,          // pvHandle
     g_pui8USBTxBuffer,              // pui8Buffer
     UART_BUFFER_SIZE,               // ui32BufferSize
-    g_pui8TxBufferWorkspace         // pvWorkspace
 };
 
 

--- a/rosserial_tivac/src/ros_lib/usb_serial_structs.c
+++ b/rosserial_tivac/src/ros_lib/usb_serial_structs.c
@@ -1,0 +1,476 @@
+//*****************************************************************************
+//
+// usb_serial_structs.c - Data structures defining this CDC USB device.
+//
+// Copyright (c) 2012-2014 Texas Instruments Incorporated.  All rights reserved.
+// Software License Agreement
+// 
+// Texas Instruments (TI) is supplying this software for use solely and
+// exclusively on TI's microcontroller products. The software is owned by
+// TI and/or its suppliers, and is protected under applicable copyright
+// laws. You may not combine this software with "viral" open-source
+// software in order to form a larger program.
+// 
+// THIS SOFTWARE IS PROVIDED "AS IS" AND WITH ALL FAULTS.
+// NO WARRANTIES, WHETHER EXPRESS, IMPLIED OR STATUTORY, INCLUDING, BUT
+// NOT LIMITED TO, IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE. TI SHALL NOT, UNDER ANY
+// CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR CONSEQUENTIAL
+// DAMAGES, FOR ANY REASON WHATSOEVER.
+// 
+// This is part of revision 2.1.0.12573 of the EK-TM4C123GXL Firmware Package.
+//
+//*****************************************************************************
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "inc/hw_types.h"
+#include "driverlib/rom.h"
+#include "driverlib/rom_map.h"
+#include "driverlib/usb.h"
+#include "usblib/usblib.h"
+#include "usblib/usbcdc.h"
+#include "usblib/usb-ids.h"
+#include "usblib/device/usbdevice.h"
+#include "usblib/device/usbdcdc.h"
+#include "usb_serial_structs.h"
+
+
+//*****************************************************************************
+//
+// Flag indicating whether or not we are currently sending a Break condition.
+//
+//*****************************************************************************
+static volatile bool g_bUSBConfigured = false;
+
+//*****************************************************************************
+//
+// Flags used to pass commands from interrupt context to the main loop.
+//
+//*****************************************************************************
+//#define COMMAND_PACKET_RECEIVED 0x00000001
+//#define COMMAND_STATUS_UPDATE   0x00000002
+//volatile uint32_t g_ui32Flags = 0;
+//char *g_pcStatus;
+
+
+//*****************************************************************************
+//
+// The languages supported by this device.
+//
+//*****************************************************************************
+const uint8_t g_pui8LangDescriptor[] =
+{
+    4,
+    USB_DTYPE_STRING,
+    USBShort(USB_LANG_EN_US)
+};
+
+//*****************************************************************************
+//
+// The manufacturer string.
+//
+//*****************************************************************************
+const uint8_t g_pui8ManufacturerString[] =
+{
+    (17 + 1) * 2,
+    USB_DTYPE_STRING,
+    'T', 0, 'e', 0, 'x', 0, 'a', 0, 's', 0, ' ', 0, 'I', 0, 'n', 0, 's', 0,
+    't', 0, 'r', 0, 'u', 0, 'm', 0, 'e', 0, 'n', 0, 't', 0, 's', 0,
+};
+
+//*****************************************************************************
+//
+// The product string.
+//
+//*****************************************************************************
+const uint8_t g_pui8ProductString[] =
+{
+    2 + (16 * 2),
+    USB_DTYPE_STRING,
+    'V', 0, 'i', 0, 'r', 0, 't', 0, 'u', 0, 'a', 0, 'l', 0, ' ', 0,
+    'C', 0, 'O', 0, 'M', 0, ' ', 0, 'P', 0, 'o', 0, 'r', 0, 't', 0
+};
+
+//*****************************************************************************
+//
+// The serial number string.
+//
+//*****************************************************************************
+const uint8_t g_pui8SerialNumberString[] =
+{
+    2 + (8 * 2),
+    USB_DTYPE_STRING,
+    '1', 0, '2', 0, '3', 0, '4', 0, '5', 0, '6', 0, '7', 0, '8', 0
+};
+
+//*****************************************************************************
+//
+// The control interface description string.
+//
+//*****************************************************************************
+const uint8_t g_pui8ControlInterfaceString[] =
+{
+    2 + (21 * 2),
+    USB_DTYPE_STRING,
+    'A', 0, 'C', 0, 'M', 0, ' ', 0, 'C', 0, 'o', 0, 'n', 0, 't', 0,
+    'r', 0, 'o', 0, 'l', 0, ' ', 0, 'I', 0, 'n', 0, 't', 0, 'e', 0,
+    'r', 0, 'f', 0, 'a', 0, 'c', 0, 'e', 0
+};
+
+//*****************************************************************************
+//
+// The configuration description string.
+//
+//*****************************************************************************
+const uint8_t g_pui8ConfigString[] =
+{
+    2 + (26 * 2),
+    USB_DTYPE_STRING,
+    'S', 0, 'e', 0, 'l', 0, 'f', 0, ' ', 0, 'P', 0, 'o', 0, 'w', 0,
+    'e', 0, 'r', 0, 'e', 0, 'd', 0, ' ', 0, 'C', 0, 'o', 0, 'n', 0,
+    'f', 0, 'i', 0, 'g', 0, 'u', 0, 'r', 0, 'a', 0, 't', 0, 'i', 0,
+    'o', 0, 'n', 0
+};
+
+//*****************************************************************************
+//
+// The descriptor string table.
+//
+//*****************************************************************************
+const uint8_t * const g_ppui8StringDescriptors[] =
+{
+    g_pui8LangDescriptor,
+    g_pui8ManufacturerString,
+    g_pui8ProductString,
+    g_pui8SerialNumberString,
+    g_pui8ControlInterfaceString,
+    g_pui8ConfigString
+};
+
+#define NUM_STRING_DESCRIPTORS (sizeof(g_ppui8StringDescriptors) /            \
+                                sizeof(uint8_t *))
+
+
+//*****************************************************************************
+//
+// The CDC device initialization and customization structures. In this case,
+// we are using USBBuffers between the CDC device class driver and the
+// application code. The function pointers and callback data values are set
+// to insert a buffer in each of the data channels, transmit and receive.
+//
+// With the buffer in place, the CDC channel callback is set to the relevant
+// channel function and the callback data is set to point to the channel
+// instance data. The buffer, in turn, has its callback set to the application
+// function and the callback data set to our CDC instance structure.
+//
+//*****************************************************************************
+extern const tUSBBuffer g_sTxBuffer;
+extern const tUSBBuffer g_sRxBuffer;
+
+tUSBDCDCDevice g_sCDCDevice =
+{
+    USB_VID_TI_1CBE,
+    USB_PID_SERIAL,
+    0,
+    USB_CONF_ATTR_SELF_PWR,
+    ControlHandler,
+    (void *)&g_sCDCDevice,
+    USBBufferEventCallback,
+    (void *)&g_sRxBuffer,
+    USBBufferEventCallback,
+    (void *)&g_sTxBuffer,
+    g_ppui8StringDescriptors,
+    NUM_STRING_DESCRIPTORS
+};
+
+//*****************************************************************************
+//
+// Receive buffer (from the USB perspective).
+//
+//*****************************************************************************
+uint8_t g_pui8USBRxBuffer[UART_BUFFER_SIZE];
+uint8_t g_pui8RxBufferWorkspace[USB_BUFFER_WORKSPACE_SIZE];
+const tUSBBuffer g_sRxBuffer =
+{
+    false,                          // This is a receive buffer.
+    RxHandler,                      // pfnCallback
+    (void *)&g_sCDCDevice,          // Callback data is our device pointer.
+    USBDCDCPacketRead,              // pfnTransfer
+    USBDCDCRxPacketAvailable,       // pfnAvailable
+    (void *)&g_sCDCDevice,          // pvHandle
+    g_pui8USBRxBuffer,              // pui8Buffer
+    UART_BUFFER_SIZE,               // ui32BufferSize
+    g_pui8RxBufferWorkspace         // pvWorkspace
+};
+
+//*****************************************************************************
+//
+// Transmit buffer (from the USB perspective).
+//
+//*****************************************************************************
+uint8_t g_pui8USBTxBuffer[UART_BUFFER_SIZE];
+uint8_t g_pui8TxBufferWorkspace[USB_BUFFER_WORKSPACE_SIZE];
+const tUSBBuffer g_sTxBuffer =
+{
+    true,                           // This is a transmit buffer.
+    TxHandler,                      // pfnCallback
+    (void *)&g_sCDCDevice,          // Callback data is our device pointer.
+    USBDCDCPacketWrite,             // pfnTransfer
+    USBDCDCTxPacketAvailable,       // pfnAvailable
+    (void *)&g_sCDCDevice,          // pvHandle
+    g_pui8USBTxBuffer,              // pui8Buffer
+    UART_BUFFER_SIZE,               // ui32BufferSize
+    g_pui8TxBufferWorkspace         // pvWorkspace
+};
+
+
+//*****************************************************************************
+//
+// Handles CDC driver notifications related to the transmit channel (data to
+// the USB host).
+//
+// \param ui32CBData is the client-supplied callback pointer for this channel.
+// \param ui32Event identifies the event we are being notified about.
+// \param ui32MsgValue is an event-specific value.
+// \param pvMsgData is an event-specific pointer.
+//
+// This function is called by the CDC driver to notify us of any events
+// related to operation of the transmit data channel (the IN channel carrying
+// data to the USB host).
+//
+// \return The return value is event-specific.
+//
+//*****************************************************************************
+uint32_t
+TxHandler(void *pvCBData, uint32_t ui32Event, uint32_t ui32MsgValue,
+          void *pvMsgData)
+{
+    //
+    // Which event have we been sent?
+    //
+    switch(ui32Event)
+    {
+        case USB_EVENT_TX_COMPLETE:
+            //
+            // Since we are using the USBBuffer, we don't need to do anything
+            // here.
+            //
+            break;
+
+        //
+        // We don't expect to receive any other events.  Ignore any that show
+        // up in a release build or hang in a debug build.
+        //
+        default:
+#ifdef DEBUG
+            while(1);
+#else
+            break;
+#endif
+
+    }
+    return(0);
+}
+
+//*****************************************************************************
+//
+// Handles CDC driver notifications related to the receive channel (data from
+// the USB host).
+//
+// \param ui32CBData is the client-supplied callback data value for this channel.
+// \param ui32Event identifies the event we are being notified about.
+// \param ui32MsgValue is an event-specific value.
+// \param pvMsgData is an event-specific pointer.
+//
+// This function is called by the CDC driver to notify us of any events
+// related to operation of the receive data channel (the OUT channel carrying
+// data from the USB host).
+//
+// \return The return value is event-specific.
+//
+//*****************************************************************************
+uint32_t
+RxHandler(void *pvCBData, uint32_t ui32Event, uint32_t ui32MsgValue,
+          void *pvMsgData)
+{
+    uint32_t ui32Count;
+
+    //
+    // Which event are we being sent?
+    //
+    switch(ui32Event)
+    {
+        //
+        // A new packet has been received.
+        //
+        case USB_EVENT_RX_AVAILABLE:
+        {
+            //
+            // Notify a new packet has beed received
+            //
+            break;
+        }
+
+        //
+        // We are being asked how much unprocessed data we have still to
+        // process. We return 0 if the UART is currently idle or 1 if it is
+        // in the process of transmitting something. The actual number of
+        // bytes in the UART FIFO is not important here, merely whether or
+        // not everything previously sent to us has been transmitted.
+        //
+        case USB_EVENT_DATA_REMAINING:
+        {
+            //
+            // Get the number of bytes in the buffer
+            //
+            ui32Count = USBBufferDataAvailable(&g_sRxBuffer);
+
+            return(ui32Count);
+        }
+
+        //
+        // We are being asked to provide a buffer into which the next packet
+        // can be read. We do not support this mode of receiving data so let
+        // the driver know by returning 0. The CDC driver should not be sending
+        // this message but this is included just for illustration and
+        // completeness.
+        //
+        case USB_EVENT_REQUEST_BUFFER:
+        {
+            return(0);
+        }
+
+        //
+        // We don't expect to receive any other events.  Ignore any that show
+        // up in a release build or hang in a debug build.
+        //
+        default:
+#ifdef DEBUG
+            while(1);
+#else
+            break;
+#endif
+    }
+
+    return(0);
+}
+
+//*****************************************************************************
+//
+// Handles CDC driver notifications related to control and setup of the device.
+//
+// \param pvCBData is the client-supplied callback pointer for this channel.
+// \param ui32Event identifies the event we are being notified about.
+// \param ui32MsgValue is an event-specific value.
+// \param pvMsgData is an event-specific pointer.
+//
+// This function is called by the CDC driver to perform control-related
+// operations on behalf of the USB host.  These functions include setting
+// and querying the serial communication parameters, setting handshake line
+// states and sending break conditions.
+//
+// \return The return value is event-specific.
+//
+//*****************************************************************************
+uint32_t
+ControlHandler(void *pvCBData, uint32_t ui32Event,
+               uint32_t ui32MsgValue, void *pvMsgData)
+{
+    // uint32_t ui32IntsOff;
+
+    //
+    // Which event are we being asked to process?
+    //
+    switch(ui32Event)
+    {
+        //
+        // We are connected to a host and communication is now possible.
+        //
+        case USB_EVENT_CONNECTED:
+            g_bUSBConfigured = true;
+
+            //
+            // Flush our buffers.
+            //
+            USBBufferFlush(&g_sTxBuffer);
+            USBBufferFlush(&g_sRxBuffer);
+
+            //
+            // Tell the main loop to update the display.
+            //
+            //ui32IntsOff = ROM_IntMasterDisable();
+            //g_pcStatus = "Connected";
+            //g_ui32Flags |= COMMAND_STATUS_UPDATE;
+            //if(!ui32IntsOff)
+            //{
+                //ROM_IntMasterEnable();
+            //}
+            break;
+
+        //
+        // The host has disconnected.
+        //
+        case USB_EVENT_DISCONNECTED:
+            g_bUSBConfigured = false;
+            //ui32IntsOff = ROM_IntMasterDisable();
+            //g_pcStatus = "Disconnected";
+            //g_ui32Flags |= COMMAND_STATUS_UPDATE;
+            //if(!ui32IntsOff)
+            //{
+                //ROM_IntMasterEnable();
+            //}
+            break;
+
+        //
+        // Return the current serial communication parameters.
+        //
+        case USBD_CDC_EVENT_GET_LINE_CODING:
+            break;
+
+        //
+        // Set the current serial communication parameters.
+        //
+        case USBD_CDC_EVENT_SET_LINE_CODING:
+            break;
+
+        //
+        // Set the current serial communication parameters.
+        //
+        case USBD_CDC_EVENT_SET_CONTROL_LINE_STATE:
+            break;
+
+        //
+        // Send a break condition on the serial line.
+        //
+        case USBD_CDC_EVENT_SEND_BREAK:
+            break;
+
+        //
+        // Clear the break condition on the serial line.
+        //
+        case USBD_CDC_EVENT_CLEAR_BREAK:
+            break;
+
+        //
+        // Ignore SUSPEND and RESUME for now.
+        //
+        case USB_EVENT_SUSPEND:
+        case USB_EVENT_RESUME:
+            break;
+
+        //
+        // We don't expect to receive any other events.  Ignore any that show
+        // up in a release build or hang in a debug build.
+        //
+        default:
+#ifdef DEBUG
+            while(1);
+#else
+            break;
+#endif
+
+    }
+
+    return(0);
+}

--- a/rosserial_tivac/src/ros_lib/usb_serial_structs.h
+++ b/rosserial_tivac/src/ros_lib/usb_serial_structs.h
@@ -1,0 +1,66 @@
+//*****************************************************************************
+//
+// usb_serial_structs.h - Data structures defining this USB CDC device.
+//
+// Copyright (c) 2012-2014 Texas Instruments Incorporated.  All rights reserved.
+// Software License Agreement
+//
+// Texas Instruments (TI) is supplying this software for use solely and
+// exclusively on TI's microcontroller products. The software is owned by
+// TI and/or its suppliers, and is protected under applicable copyright
+// laws. You may not combine this software with "viral" open-source
+// software in order to form a larger program.
+//
+// THIS SOFTWARE IS PROVIDED "AS IS" AND WITH ALL FAULTS.
+// NO WARRANTIES, WHETHER EXPRESS, IMPLIED OR STATUTORY, INCLUDING, BUT
+// NOT LIMITED TO, IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE. TI SHALL NOT, UNDER ANY
+// CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR CONSEQUENTIAL
+// DAMAGES, FOR ANY REASON WHATSOEVER.
+//
+// This is part of revision 2.1.0.12573 of the EK-TM4C123GXL Firmware Package.
+//
+//*****************************************************************************
+
+#ifndef _USB_SERIAL_STRUCTS_H_
+#define _USB_SERIAL_STRUCTS_H_
+
+//*****************************************************************************
+//
+// The size of the transmit and receive buffers used for the redirected UART.
+// This number should be a power of 2 for best performance.  256 is chosen
+// pretty much at random though the buffer should be at least twice the size of
+// a maxmum-sized USB packet.
+//
+//*****************************************************************************
+#ifdef __cpluspus
+extern "C" {
+#endif
+
+#ifndef UART_BUFFER_SIZE
+#define UART_BUFFER_SIZE 256
+#endif
+
+//*****************************************************************************
+//
+// CDC device callback function prototypes.
+//
+//*****************************************************************************
+uint32_t RxHandler(void *pvCBData, uint32_t ui32Event,
+                   uint32_t ui32MsgValue, void *pvMsgData);
+uint32_t TxHandler(void *pvCBData, uint32_t ui32Event,
+                   uint32_t ui32MsgValue, void *pvMsgData);
+uint32_t ControlHandler(void *pvCBData, uint32_t ui32Event,
+                        uint32_t ui32MsgValue, void *pvMsgData);
+
+extern const tUSBBuffer g_sTxBuffer;
+extern const tUSBBuffer g_sRxBuffer;
+extern tUSBDCDCDevice g_sCDCDevice;
+extern uint8_t g_pui8USBTxBuffer[];
+extern uint8_t g_pui8USBRxBuffer[];
+
+#ifdef __cpluspus
+}
+#endif
+
+#endif

--- a/rosserial_tivac/src/ros_lib/usb_serial_structs.h
+++ b/rosserial_tivac/src/ros_lib/usb_serial_structs.h
@@ -53,8 +53,8 @@ uint32_t TxHandler(void *pvCBData, uint32_t ui32Event,
 uint32_t ControlHandler(void *pvCBData, uint32_t ui32Event,
                         uint32_t ui32MsgValue, void *pvMsgData);
 
-extern const tUSBBuffer g_sTxBuffer;
-extern const tUSBBuffer g_sRxBuffer;
+extern tUSBBuffer g_sTxBuffer;
+extern tUSBBuffer g_sRxBuffer;
 extern tUSBDCDCDevice g_sCDCDevice;
 extern uint8_t g_pui8USBTxBuffer[];
 extern uint8_t g_pui8USBRxBuffer[];

--- a/rosserial_tivac/src/ros_lib_energia/TivaCHardware.h
+++ b/rosserial_tivac/src/ros_lib_energia/TivaCHardware.h
@@ -1,0 +1,87 @@
+/* 
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2011, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *  * Neither the name of Willow Garage, Inc. nor the names of its
+ *    contributors may be used to endorse or promote prducts derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+/*
+ * Copyright (c) 2015, Robosavvy Ltd.
+ * Author: Vitor Matos
+ * Based on rosserial_arduino's ArduinoHardware.h with the intent to make it  work on TI's Energia.
+ */
+
+#ifndef TIVACHARDWARE_H
+#define TIVACHARDWARE_H
+
+#include <Energia.h>
+#include <HardwareSerial.h>
+#define SERIAL_CLASS HardwareSerial
+
+class TivaCHardware {
+  public:
+    TivaCHardware(SERIAL_CLASS* io , long baud= 57600){
+      iostream = io;
+      baud_ = baud;
+    }
+
+    TivaCHardware()
+    {
+      iostream = &Serial;
+      baud_ = 57600;
+    }
+    TivaCHardware(TivaCHardware& h){
+      this->iostream = iostream;
+      this->baud_ = h.baud_;
+    }
+  
+    void setBaud(long baud){
+      this->baud_= baud;
+    }
+  
+    int getBaud(){return baud_;}
+
+    void init(){
+      iostream->begin(baud_);
+    }
+
+    int read(){return iostream->read();};
+    void write(uint8_t* data, int length){
+      for(int i=0; i<length; i++)
+        iostream->write(data[i]);
+    }
+
+    unsigned long time(){return millis();}
+
+  protected:
+    SERIAL_CLASS* iostream;
+    long baud_;
+};
+
+#endif  // TIVAHARDWARE_H

--- a/rosserial_tivac/src/ros_lib_energia/examples/chatter/chatter.ino
+++ b/rosserial_tivac/src/ros_lib_energia/examples/chatter/chatter.ino
@@ -1,0 +1,28 @@
+/*
+ * rosserial Publisher Example
+ * Prints "hello world!"
+ */
+
+#include <ros.h>
+#include <std_msgs/String.h>
+
+ros::NodeHandle nh;
+std_msgs::String str_msg;
+ros::Publisher chatter("chatter", &str_msg);
+
+char hello[13] = "hello world!";
+
+void setup()
+{
+  nh.initNode();
+  nh.advertise(chatter);
+}
+
+void loop()
+{
+  str_msg.data = hello;
+  chatter.publish( &str_msg );
+  nh.spinOnce();
+  delay(1000);
+}
+

--- a/rosserial_tivac/src/ros_lib_energia/examples/rgb/rgb.ino
+++ b/rosserial_tivac/src/ros_lib_energia/examples/rgb/rgb.ino
@@ -1,0 +1,37 @@
+/*
+ * rosserial subscriber Example
+ */
+ 
+#include <ros.h>
+#include <std_msgs/ColorRGBA.h>
+
+void color_cb( const std_msgs::ColorRGBA& msg)
+{
+  analogWrite(RED_LED,msg.r*255);
+  analogWrite(GREEN_LED,msg.g*255);
+  analogWrite(BLUE_LED,msg.b*255);
+}
+
+ros::NodeHandle nh;
+ros::Subscriber<std_msgs::ColorRGBA> color_sub("led", &color_cb );
+
+void setup()
+{
+  pinMode(RED_LED, OUTPUT);
+  pinMode(GREEN_LED, OUTPUT);
+  pinMode(BLUE_LED, OUTPUT);
+
+  analogWrite(RED_LED,255);
+  analogWrite(GREEN_LED,255);
+  analogWrite(BLUE_LED,255);
+  
+  nh.initNode();
+  nh.subscribe(color_sub);
+}
+
+void loop()
+{
+  nh.spinOnce();
+  delay(100);
+}
+

--- a/rosserial_tivac/src/ros_lib_energia/ros.h
+++ b/rosserial_tivac/src/ros_lib_energia/ros.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2015, Robosavvy Ltd.
+ * All rights reserved.
+ * Author: Vitor Matos
+ * 
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the 
+ * following conditions are met:
+ * 
+ *   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the 
+ * following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the 
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote 
+ * products derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED 
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ROS_LIB_ENERGIA_ROS_H
+#define ROS_LIB_ENERGIA_ROS_H
+
+#include "ros/node_handle.h"
+#include "TivaCHardware.h"
+
+namespace ros
+{
+  typedef NodeHandle_<TivaCHardware> NodeHandle;
+}
+#endif  // ROS_LIB_ENERGIA_ROS_H

--- a/rosserial_tivac/src/ros_lib_energia/tests/array_test/array_test.ino
+++ b/rosserial_tivac/src/ros_lib_energia/tests/array_test/array_test.ino
@@ -1,0 +1,49 @@
+/* 
+ * rosserial::geometry_msgs::PoseArray Test
+ * Sums an array, publishes sum 
+ */
+
+#include <ros.h>
+#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/PoseArray.h>
+
+
+ros::NodeHandle nh;
+
+
+bool set_; 
+
+
+geometry_msgs::Pose sum_msg;
+ros::Publisher p("sum", &sum_msg);
+
+void messageCb(const geometry_msgs::PoseArray& msg){
+  sum_msg.position.x = 0;
+  sum_msg.position.y = 0;
+  sum_msg.position.z = 0;
+  for(int i = 0; i < msg.poses_length; i++)
+  {
+    sum_msg.position.x += msg.poses[i].position.x;
+    sum_msg.position.y += msg.poses[i].position.y;
+    sum_msg.position.z += msg.poses[i].position.z;
+  }
+  digitalWrite(RED_LED, HIGH-digitalRead(RED_LED));   // blink the led
+}
+
+ros::Subscriber<geometry_msgs::PoseArray> s("poses",messageCb);
+
+void setup()
+{ 
+  pinMode(RED_LED, OUTPUT);
+  nh.initNode();
+  nh.subscribe(s);
+  nh.advertise(p);
+}
+
+void loop()
+{  
+  p.publish(&sum_msg);
+  nh.spinOnce();
+  delay(10);
+}
+

--- a/rosserial_tivac/src/ros_lib_energia/tests/array_test/test_data
+++ b/rosserial_tivac/src/ros_lib_energia/tests/array_test/test_data
@@ -1,0 +1,36 @@
+Test data example:
+
+rostopic pub /poses geometry_msgs/PoseArray "header:
+  seq: 0
+  stamp:
+    secs: 0
+    nsecs: 0
+  frame_id: ''
+poses:
+- position:
+    x: 0.5
+    y: 0.0
+    z: 0.0
+  orientation:
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+- position:
+    x: 0.0
+    y: 1.7
+    z: -1.0
+  orientation:
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 0.0
+- position:
+    x: 0.0
+    y: 0.0
+    z: 2.0
+  orientation:
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 0.0"

--- a/rosserial_tivac/src/ros_lib_energia/tests/float64_test/float64_test.ino
+++ b/rosserial_tivac/src/ros_lib_energia/tests/float64_test/float64_test.ino
@@ -1,0 +1,38 @@
+/* 
+ * rosserial::std_msgs::Float64 Test
+ * Receives a Float64 input, subtracts 1.0, and publishes it
+ */
+
+#include <ros.h>
+#include <std_msgs/Float64.h>
+
+
+ros::NodeHandle nh;
+
+float x; 
+
+void messageCb( const std_msgs::Float64& msg){
+  x = msg.data - 1.0;
+  digitalWrite(RED_LED, HIGH-digitalRead(RED_LED));   // blink the led
+}
+
+std_msgs::Float64 test;
+ros::Subscriber<std_msgs::Float64> s("your_topic", &messageCb);
+ros::Publisher p("my_topic", &test);
+
+void setup()
+{
+  pinMode(RED_LED, OUTPUT);
+  nh.initNode();
+  nh.advertise(p);
+  nh.subscribe(s);
+}
+
+void loop()
+{
+  test.data = x;
+  p.publish( &test );
+  nh.spinOnce();
+  delay(10);
+}
+

--- a/rosserial_tivac/src/ros_lib_energia/tests/time_test/time_test.ino
+++ b/rosserial_tivac/src/ros_lib_energia/tests/time_test/time_test.ino
@@ -1,0 +1,30 @@
+/* 
+ * rosserial::std_msgs::Time Test
+ * Publishes current time
+ */
+
+#include <ros.h>
+#include <ros/time.h>
+#include <std_msgs/Time.h>
+
+
+ros::NodeHandle  nh;
+
+std_msgs::Time test;
+ros::Publisher p("my_topic", &test);
+
+void setup()
+{
+  pinMode(RED_LED, OUTPUT);
+  nh.initNode();
+  nh.advertise(p);
+}
+
+void loop()
+{  
+  test.data = nh.now();
+  p.publish( &test );
+  nh.spinOnce();
+  delay(10);
+}
+

--- a/rosserial_tivac/src/rosserial_tivac/make_libraries
+++ b/rosserial_tivac/src/rosserial_tivac/make_libraries
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+
+#####################################################################
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Willow Garage
+# Copyright (c) 2014, Mike Purvis
+# Copyright (c) 2015, Vitor Matos
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+THIS_PACKAGE = "rosserial_tivac"
+
+__usage__ = """
+This generic make_libraries generates the non-platform specific part of a
+rosserial client library, including messages. It assumes the target platform
+has native float64 support, and is therefore unsuitable for use with AVR.
+To generate messages for AVR, use the make_libraries script in
+rosserial_arduino.
+This script also does not provide the ros.h file or other hardware
+abstraction. This will need to be supplied by the user.
+rosrun rosserial_tivac make_libraries <output_path>
+"""
+
+import rospkg
+
+import rosserial_client
+from rosserial_client.make_library import *
+
+# for copying files
+import shutil
+
+ROS_TO_EMBEDDED_TYPES = {
+    'bool'    :   ('bool',              1, PrimitiveDataType, []),
+    'byte'    :   ('int8_t',            1, PrimitiveDataType, []),
+    'int8'    :   ('int8_t',            1, PrimitiveDataType, []),
+    'char'    :   ('uint8_t',           1, PrimitiveDataType, []),
+    'uint8'   :   ('uint8_t',           1, PrimitiveDataType, []),
+    'int16'   :   ('int16_t',           2, PrimitiveDataType, []),
+    'uint16'  :   ('uint16_t',          2, PrimitiveDataType, []),
+    'int32'   :   ('int32_t',           4, PrimitiveDataType, []),
+    'uint32'  :   ('uint32_t',          4, PrimitiveDataType, []),
+    'int64'   :   ('int64_t',           8, PrimitiveDataType, []),
+    'uint64'  :   ('uint64_t',          8, PrimitiveDataType, []),
+    'float32' :   ('float',             4, PrimitiveDataType, []),
+    'float64' :   ('double',            8, PrimitiveDataType, []),
+    'time'    :   ('ros::Time',         8, TimeDataType, ['ros/time']),
+    'duration':   ('ros::Duration',     8, TimeDataType, ['ros/duration']),
+    'string'  :   ('char*',             0, StringDataType, []),
+    'Header'  :   ('std_msgs::Header',  0, MessageDataType, ['std_msgs/Header'])
+}
+
+# Enforce correct inputs
+if (len(sys.argv) < 2):
+    print(__usage__)
+    exit(1)
+
+# Sanitize output path
+path = sys.argv[1]
+if path[-1] == "/":
+    path = path[0:-1]
+print "\nExporting to %s" % path
+
+rospack = rospkg.RosPack()
+
+# Copy hardware specific ros_lib
+rosserial_specific_dir = rospack.get_path(THIS_PACKAGE)
+shutil.copytree(rosserial_specific_dir+"/src/ros_lib", path+"/ros_lib")
+
+# Generate and copy remaining ros_lib files
+rosserial_client_copy_files(rospack, path+"/ros_lib/")
+rosserial_generate(rospack, path+"/ros_lib", ROS_TO_EMBEDDED_TYPES)

--- a/rosserial_tivac/src/rosserial_tivac/make_libraries.py
+++ b/rosserial_tivac/src/rosserial_tivac/make_libraries.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+
+#####################################################################
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Willow Garage
+# Copyright (c) 2014, Mike Purvis
+# Copyright (c) 2015, Vitor Matos
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+THIS_PACKAGE = "rosserial_tivac"
+
+__usage__ = """
+This generic make_libraries generates the non-platform specific part of a
+rosserial client library, including messages. It assumes the target platform
+has native float64 support, and is therefore unsuitable for use with AVR.
+To generate messages for AVR, use the make_libraries script in
+rosserial_arduino.
+This script also does not provide the ros.h file or other hardware
+abstraction. This will need to be supplied by the user.
+rosrun rosserial_tivac make_libraries <output_path>
+"""
+
+import rospkg
+
+import rosserial_client
+from rosserial_client.make_library import *
+
+# for copying files
+import shutil
+
+ROS_TO_EMBEDDED_TYPES = {
+    'bool'    :   ('bool',              1, PrimitiveDataType, []),
+    'byte'    :   ('int8_t',            1, PrimitiveDataType, []),
+    'int8'    :   ('int8_t',            1, PrimitiveDataType, []),
+    'char'    :   ('uint8_t',           1, PrimitiveDataType, []),
+    'uint8'   :   ('uint8_t',           1, PrimitiveDataType, []),
+    'int16'   :   ('int16_t',           2, PrimitiveDataType, []),
+    'uint16'  :   ('uint16_t',          2, PrimitiveDataType, []),
+    'int32'   :   ('int32_t',           4, PrimitiveDataType, []),
+    'uint32'  :   ('uint32_t',          4, PrimitiveDataType, []),
+    'int64'   :   ('int64_t',           8, PrimitiveDataType, []),
+    'uint64'  :   ('uint64_t',          8, PrimitiveDataType, []),
+    'float32' :   ('float',             4, PrimitiveDataType, []),
+    'float64' :   ('double',            8, PrimitiveDataType, []),
+    'time'    :   ('ros::Time',         8, TimeDataType, ['ros/time']),
+    'duration':   ('ros::Duration',     8, TimeDataType, ['ros/duration']),
+    'string'  :   ('char*',             0, StringDataType, []),
+    'Header'  :   ('std_msgs::Header',  0, MessageDataType, ['std_msgs/Header'])
+}
+
+# Enforce correct inputs
+if (len(sys.argv) < 2):
+    print(__usage__)
+    exit(1)
+
+# Sanitize output path
+path = sys.argv[1]
+if path[-1] == "/":
+    path = path[0:-1]
+print "\nExporting to %s" % path
+
+rospack = rospkg.RosPack()
+
+# Copy hardware specific ros_lib
+rosserial_specific_dir = rospack.get_path(THIS_PACKAGE)
+shutil.copytree(rosserial_specific_dir+"/src/ros_lib_energia", path+"/ros_lib")
+
+# Generate and copy remaining ros_lib files
+rosserial_client_copy_files(rospack, path+"/ros_lib/")
+rosserial_generate(rospack, path+"/ros_lib", ROS_TO_EMBEDDED_TYPES)

--- a/rosserial_tivac/src/rosserial_tivac/make_libraries_energia
+++ b/rosserial_tivac/src/rosserial_tivac/make_libraries_energia
@@ -38,14 +38,13 @@
 THIS_PACKAGE = "rosserial_tivac"
 
 __usage__ = """
-This generic make_libraries generates the non-platform specific part of a
-rosserial client library, including messages. It assumes the target platform
-has native float64 support, and is therefore unsuitable for use with AVR.
-To generate messages for AVR, use the make_libraries script in
-rosserial_arduino.
-This script also does not provide the ros.h file or other hardware
-abstraction. This will need to be supplied by the user.
-rosrun rosserial_tivac make_libraries <output_path>
+This script generates the message library and copies the rosserial client library
+for Energia based projects.
+Usage: rosrun rosserial_tivac make_libraries_energia <output_path>
+
+Example:
+Navigate to your sketches directory and run:
+rosrun rosserial_tivac make_libraries_energia .
 """
 
 import rospkg

--- a/rosserial_tivac/src/rosserial_tivac/make_libraries_tiva
+++ b/rosserial_tivac/src/rosserial_tivac/make_libraries_tiva
@@ -38,14 +38,11 @@
 THIS_PACKAGE = "rosserial_tivac"
 
 __usage__ = """
-This generic make_libraries generates the non-platform specific part of a
-rosserial client library, including messages. It assumes the target platform
-has native float64 support, and is therefore unsuitable for use with AVR.
-To generate messages for AVR, use the make_libraries script in
-rosserial_arduino.
-This script also does not provide the ros.h file or other hardware
-abstraction. This will need to be supplied by the user.
-rosrun rosserial_tivac make_libraries <output_path>
+This script generates the message library for TivaC projects.
+It also copies the rosserial client for make/cmake projects using GNU arm-none-eabi toolchain.
+
+Usage:
+rosrun rosserial_tivac make_libraries_tiva <output_path>
 """
 
 import rospkg

--- a/rosserial_tivac/tivac-cmake/cmake/TivaCToolchain.cmake
+++ b/rosserial_tivac/tivac-cmake/cmake/TivaCToolchain.cmake
@@ -1,0 +1,149 @@
+cmake_minimum_required(VERSION 2.8.3)
+include(CMakeParseArguments)
+
+if(NOT WIN32)
+  string(ASCII 27 Esc)
+  set(Red         "${Esc}[31m")
+  set(ColourReset "${Esc}[m")
+endif()
+
+# Set cross compilation information
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+# GCC toolchain prefix
+set(TOOLCHAIN_PREFIX "arm-none-eabi")
+
+set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_ASM_COMPILER ${TOOLCHAIN_PREFIX}-as)
+set(CMAKE_AR ${TOOLCHAIN_PREFIX}-ar)
+set(CMAKE_OBJCOPY ${TOOLCHAIN_PREFIX}-objcopy)
+set(CMAKE_OBJDUMP ${TOOLCHAIN_PREFIX}-objdump)
+set(CMAKE_SIZE ${TOOLCHAIN_PREFIX}-size)
+
+# This hangs CMake when called by catkin
+# enable_language(ASM) 
+
+set(CPU "-mcpu=cortex-m4")
+set(FPU "-mfpu=fpv4-sp-d16 -mfloat-abi=softfp")
+# Cache if it set before project command (e.g. in toolchain):
+set(CMAKE_ASM_FLAGS "-mthumb ${CPU}  ${FPU} -MD" CACHE STRING "" FORCE)
+set(CMAKE_C_FLAGS "-mthumb ${CPU} ${FPU} -std=gnu99 -Os -ffunction-sections -fdata-sections -MD -Wall -pedantic -fsingle-precision-constant" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS "-mthumb ${CPU} ${FPU} -std=c++11 -Os -ffunction-sections -fdata-sections -MD -Wall -pedantic -fno-exceptions -fno-rtti -fsingle-precision-constant -nostartfiles" CACHE STRING "" FORCE)
+
+set(LINKER_SCRIPT_TM4C123GXL ${CMAKE_CURRENT_LIST_DIR}/../tm4c123g.ld)
+set(LINKER_SCRIPT_TM4C1294XL ${CMAKE_CURRENT_LIST_DIR}/../tm4c1294.ld)
+set(LINKER_SPECS ${CMAKE_CURRENT_LIST_DIR}/../tiva.specs)
+
+set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
+set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
+set(CMAKE_EXE_LINKER_FLAGS "-T${LINKER_SCRIPT_TM4C123GXL} -specs=${LINKER_SPECS} -Wl,-Map=memmap.map" CACHE STRING "" FORCE)
+
+
+# Processor specific definitions
+
+add_definitions(-Dgcc)
+
+# How could we find Tivaware SDK paths? similarly to Arduino toolchain?
+# Just like ArduinoToolchain.cmake from Tomasz Bogdal (QueezyTheGreat) - https://github.com/queezythegreat/arduino-cmake
+set(TIVA_WARE_PATH $ENV{TIVA_WARE_PATH})
+include_directories($ENV{TIVA_WARE_PATH})
+set(FLASH_EXECUTABLE $ENV{TIVA_FLASH_EXECUTABLE})
+
+# Configures FLAGS
+function(CONFIGURE_BOARD BOARD)
+  message(STATUS "[TIVAC] Configuring board for ${CMAKE_PROJECT_NAME}")
+  
+  if(${BOARD} STREQUAL "tm4c123gxl")
+    add_definitions(-DPART_TM4C123GH6PM)
+    add_definitions(-DTARGET_IS_TM4C123_RA1)
+    set(CMAKE_EXE_LINKER_FLAGS "-T${LINKER_SCRIPT_TM4C123GXL} -specs=${LINKER_SPECS} -Wl,-Map=memmap.map" CACHE STRING "" FORCE)
+  elseif(${BOARD} STREQUAL "tm4c1294xl")
+    add_definitions(-DPART_TM4C1294NCPDT)
+    add_definitions(-DTARGET_IS_TM4C129_RA0)
+    set(CMAKE_EXE_LINKER_FLAGS "-T${LINKER_SCRIPT_TM4C1294XL} -specs=${LINKER_SPECS} -Wl,-Map=memmap.map" CACHE STRING "" FORCE)
+  else()
+    message(FATAL_ERROR "${Red}[TIVAC] Invalid BOARD set for target ${CMAKE_PROJECT_NAME}${ColourReset}")
+  endif()
+  
+endfunction()
+
+# Generates targets based on options and definitions
+function(GENERATE_TIVAC_FIRMWARE)
+  message(STATUS "[TIVAC] Generating firmware ${CMAKE_PROJECT_NAME}")
+  set(options USB)
+  set(oneValueArgs BOARD STARTUP)
+  set(multiValueArgs SRCS INCS LIBS)
+  cmake_parse_arguments(INPUT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+  
+  if(NOT INPUT_BOARD)
+    message(FATAL_ERROR "${Red}[TIVAC] BOARD not set for target ${CMAKE_PROJECT_NAME}${ColourReset}")
+  endif()
+  configure_board(${INPUT_BOARD})
+  
+  if(INPUT_USB)
+    add_definitions(-DUSE_USBCON)
+    
+    # usblib dependency
+    add_library(usblib STATIC IMPORTED)
+    set_target_properties(usblib PROPERTIES
+      IMPORTED_LOCATION ${TIVA_WARE_PATH}/usblib/gcc/libusb.a
+    )
+    add_custom_target(build_usblib ALL 
+      COMMAND ${CMAKE_MAKE_PROGRAM}
+      WORKING_DIRECTORY ${TIVA_WARE_PATH}/usblib
+      COMMENT "[TIVAC] Building usblib using original makefile"
+    )
+    list(APPEND OTHER_LIBS usblib)
+    list(APPEND OTHER_SRCS ${ROS_LIB_DIR}/usb_serial_structs.c)
+    add_dependencies(usblib build_usblib)
+  endif()
+  
+  if(INPUT_STARTUP)
+    message(STATUS "[TIVAC] Using custom startup file ${INPUT_STARTUP} for ${CMAKE_PROJECT_NAME}")
+    list(APPEND INPUT_SRCS ${INPUT_STARTUP})
+  else()
+    list(APPEND INPUT_SRCS ${ROS_LIB_DIR}/startup_gcc.c)
+  endif()
+
+  # driverlib dependency
+  add_library(driverlib STATIC IMPORTED)
+  set_target_properties(driverlib PROPERTIES
+    IMPORTED_LOCATION ${TIVA_WARE_PATH}/driverlib/gcc/libdriver.a
+  )
+  add_custom_target(build_driverlib 
+    COMMAND ${CMAKE_MAKE_PROGRAM}
+    WORKING_DIRECTORY ${TIVA_WARE_PATH}/driverlib
+    COMMENT "[TIVAC] Building driverlib using original makefile"
+  )
+  add_dependencies(driverlib build_driverlib)
+
+  include_directories(${INPUT_INCS})
+  add_executable(${CMAKE_PROJECT_NAME}.axf
+    ${INPUT_SRCS}
+    ${TIVA_WARE_PATH}/utils/ringbuf.c
+    ${ROS_LIB_DIR}/duration.cpp 
+    ${ROS_LIB_DIR}/time.cpp
+    ${OTHER_SRCS}
+  )
+  target_link_libraries(${CMAKE_PROJECT_NAME}.axf 
+    ${INPUT_LIBS}
+    ${OTHER_LIBS}
+    driverlib
+  )
+
+  add_custom_target("dump" DEPENDS ${CMAKE_PROJECT_NAME}.axf 
+    COMMAND ${CMAKE_OBJDUMP} -x ${EXECUTABLE_OUTPUT_PATH}/${CMAKE_PROJECT_NAME}.axf
+  )
+  
+  add_custom_target("size" DEPENDS ${CMAKE_PROJECT_NAME}.axf 
+    COMMAND ${CMAKE_SIZE} -A -d ${EXECUTABLE_OUTPUT_PATH}/${CMAKE_PROJECT_NAME}.axf
+    COMMAND ${CMAKE_SIZE} -A -x ${EXECUTABLE_OUTPUT_PATH}/${CMAKE_PROJECT_NAME}.axf
+  )
+
+  add_custom_target("flash" DEPENDS ${CMAKE_PROJECT_NAME}.axf 
+    COMMAND ${CMAKE_OBJCOPY} -O binary ${EXECUTABLE_OUTPUT_PATH}/${CMAKE_PROJECT_NAME}.axf ${EXECUTABLE_OUTPUT_PATH}/${CMAKE_PROJECT_NAME}.bin 
+    COMMAND ${FLASH_EXECUTABLE} ${EXECUTABLE_OUTPUT_PATH}/${CMAKE_PROJECT_NAME}.bin
+  )
+endfunction()

--- a/rosserial_tivac/tivac-cmake/cmake/TivaCToolchain.cmake
+++ b/rosserial_tivac/tivac-cmake/cmake/TivaCToolchain.cmake
@@ -1,3 +1,47 @@
+# 
+# Copyright (c) 2015, Robosavvy Ltd.
+# Author: Vitor Matos
+#
+# Quick and dirty cmake script which prepares cross-compilation for catkinized, rosserial_client enabled projects.
+# 
+# Requires two enviroment variables:
+#   TIVA_WARE_PATH        - TI TivaWare SDK path
+#   TIVA_FLASH_EXECUTABLE - lm4flash tool executable
+#
+# Defines function to be included in cross-compiled project's CMakeLists.txt:
+#   generate_tivac_firmware
+# 
+# With Arguments:
+#     USB     - Optional argument, if you wish to have rosserial over USB CDC device.
+#     BOARD   - Required. Takes one argument, tm4c123gxl or tm4c1294xl.
+#     STARTUP - Optional argument. Takes the name of custom startup file.
+#     SRCS    - Required. List of source files to compile.
+#     INCS    - Optional. List of include directories.
+#     LIBS    - Optional. List of libraries to be linked.
+#
+# Creates custom targets for project:
+#   <parent_catkin_project>_${CMAKE_PROJECT_NAME}.axf   - Build binary file
+#   <parent_catkin_project>_${CMAKE_PROJECT_NAME}_flash - Flashes board with binary file
+#   <parent_catkin_project>_${CMAKE_PROJECT_NAME}_size  - Prints out the size of sections and totals of binary file
+#   <parent_catkin_project>_${CMAKE_PROJECT_NAME}_dump  - Prints table of symbols and such
+#
+# Example usage:
+#
+#   generate_tivac_firmware(
+#     USB
+#     STARTUP custom_startup.c
+#     SRCS buttons.cpp buttons.c
+#     INCS .
+#     BOARD tm4c123gxl
+#   )
+# 
+# This example sets rosserial communication through USB CDC device. 
+# Adds two source files to be compiled on the project.
+# Includes the project directory.
+# It will compile the project for tm4c123gxl board.
+# Includes a custom startup file to specify on the interrupt vector some interrupt handlers.
+# 
+
 cmake_minimum_required(VERSION 2.8.3)
 include(CMakeParseArguments)
 
@@ -13,7 +57,6 @@ set(CMAKE_SYSTEM_PROCESSOR arm)
 
 # GCC toolchain prefix
 set(TOOLCHAIN_PREFIX "arm-none-eabi")
-
 set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}-gcc)
 set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
 set(CMAKE_ASM_COMPILER ${TOOLCHAIN_PREFIX}-as)
@@ -40,9 +83,7 @@ set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 set(CMAKE_EXE_LINKER_FLAGS "-T${LINKER_SCRIPT_TM4C123GXL} -specs=${LINKER_SPECS} -Wl,-Map=memmap.map" CACHE STRING "" FORCE)
 
-
 # Processor specific definitions
-
 add_definitions(-Dgcc)
 
 # How could we find Tivaware SDK paths? similarly to Arduino toolchain?

--- a/rosserial_tivac/tivac-cmake/tiva.specs
+++ b/rosserial_tivac/tivac-cmake/tiva.specs
@@ -1,0 +1,5 @@
+*link:
+--entry ResetISR --gc-sections
+
+*lib:
+-lgcc -lc -lm -lnosys

--- a/rosserial_tivac/tivac-cmake/tm4c123g.ld
+++ b/rosserial_tivac/tivac-cmake/tm4c123g.ld
@@ -1,0 +1,88 @@
+/******************************************************************************
+ *  Based on Energia's ld script
+ ******************************************************************************/
+
+MEMORY
+{
+    FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x00040000
+    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00008000
+}
+
+SECTIONS
+{
+    .text :
+    {
+        . = ALIGN(4);
+        _text = .;
+        KEEP(*(.isr_vector))
+        *(.text .text* .gnu.linkonce.t.*)
+        *(.glue_7t) *(.glue_7)
+        *(.rodata .rodata* .gnu.linkonce.r.*)
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+        
+        . = ALIGN(4);
+        KEEP(*(.init))
+
+        . = ALIGN(4);
+        __preinit_array_start = .;
+        KEEP(*(SORT(.preinit_array*)))
+        KEEP(*(.preinit_array))
+        __preinit_array_end = .;
+        
+        . = ALIGN(4);
+        __init_array_start = .;
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        __init_array_end = .;
+        
+        . = ALIGN(4);
+        KEEP(*(.fini))
+
+        . = ALIGN(4);
+        __fini_array_start = .;
+        KEEP(*(.fini_array))
+        KEEP(*(SORT(.fini_array.*)))
+        __fini_array_end = .;
+
+        . = ALIGN(4);
+        _etext = .;
+    } > FLASH
+
+    .data : AT(ADDR(.text) + SIZEOF(.text))
+    {
+        . = ALIGN(4);
+        _data = .;
+        *(vtable)
+        *(.data .data* .gnu.linkonce.d.*)
+        _edata = .;
+    } > SRAM
+    
+    .bss (NOLOAD):
+    {
+        . = ALIGN(4);
+        _bss = .;
+        __bss_start__ = _bss;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4); 
+        _ebss = .;
+        __bss_end__ = _ebss;
+        . = ALIGN(8);
+    } > SRAM
+    
+    PROVIDE_HIDDEN(__exidx_start = .);
+    .ARM.exidx :
+    {
+      *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > SRAM
+    PROVIDE_HIDDEN(__exidx_end = .);
+    
+    . = ALIGN(4);
+    _end = . ;
+}
+
+/* end of allocated ram is start of heap, heap grows up towards stack*/
+PROVIDE(end = _end);
+
+/* top of stack starts at end of ram, stack grows down towards heap */
+PROVIDE(_estack = ORIGIN(SRAM) + LENGTH(SRAM));

--- a/rosserial_tivac/tivac-cmake/tm4c1294.ld
+++ b/rosserial_tivac/tivac-cmake/tm4c1294.ld
@@ -1,0 +1,88 @@
+/******************************************************************************
+ *  Based on Energia's ld script
+ ******************************************************************************/
+
+MEMORY
+{
+    FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x00100000
+    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00040000
+}
+
+SECTIONS
+{
+    .text :
+    {
+        . = ALIGN(4);
+        _text = .;
+        KEEP(*(.isr_vector))
+        *(.text .text* .gnu.linkonce.t.*)
+        *(.glue_7t) *(.glue_7)
+        *(.rodata .rodata* .gnu.linkonce.r.*)
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+        
+        . = ALIGN(4);
+        KEEP(*(.init))
+
+        . = ALIGN(4);
+        __preinit_array_start = .;
+        KEEP(*(SORT(.preinit_array*)))
+        KEEP(*(.preinit_array))
+        __preinit_array_end = .;
+        
+        . = ALIGN(4);
+        __init_array_start = .;
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        __init_array_end = .;
+        
+        . = ALIGN(4);
+        KEEP(*(.fini))
+
+        . = ALIGN(4);
+        __fini_array_start = .;
+        KEEP(*(.fini_array))
+        KEEP(*(SORT(.fini_array.*)))
+        __fini_array_end = .;
+
+        . = ALIGN(4);
+        _etext = .;
+    } > FLASH
+
+    .data : AT(ADDR(.text) + SIZEOF(.text))
+    {
+        . = ALIGN(4);
+        _data = .;
+        *(vtable)
+        *(.data .data* .gnu.linkonce.d.*)
+        _edata = .;
+    } > SRAM
+    
+    .bss (NOLOAD):
+    {
+        . = ALIGN(4);
+        _bss = .;
+        __bss_start__ = _bss;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4); 
+        _ebss = .;
+        __bss_end__ = _ebss;
+        . = ALIGN(8);
+    } > SRAM
+    
+    PROVIDE_HIDDEN(__exidx_start = .);
+    .ARM.exidx :
+    {
+      *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > SRAM
+    PROVIDE_HIDDEN(__exidx_end = .);
+    
+    . = ALIGN(4);
+    _end = . ;
+}
+
+/* end of allocated ram is start of heap, heap grows up towards stack*/
+PROVIDE(end = _end);
+
+/* top of stack starts at end of ram, stack grows down towards heap */
+PROVIDE(_estack = ORIGIN(SRAM) + LENGTH(SRAM));


### PR DESCRIPTION
Hello all!

We are proud to share our rosserial package for TI's launchpad boards.
This package allows you to use rosserial on TM4C123GXL and TM4C129XL evaluation boards, using:
- Energia IDE (arduino like)
- arm-none-eabi GNU toolchain through rosserial_client catking type build.

Documentation and tutorials are ready and can be found here:
[rosserial_tivac](http://wiki.ros.org/rosserial_tivac)
[Tutorials](http://wiki.ros.org/rosserial_tivac/Tutorials)

Let us know what you think. If it would be worth the inclusion of the package on rosserials' repo, tips, critics and comments.

EDIT: package versioning, repositories on package.xml and such details will need revision.

Cheers
