### PR TITLE
[TIVAC] Improving Hardware class. No more error of multiple definitions

### DIFF
--- a/rosserial_tivac/src/ros_lib/tivac_hardware.cpp
+++ b/rosserial_tivac/src/ros_lib/tivac_hardware.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2015, Robosavvy Ltd.
+ * All rights reserved.
+ * Author: Vitor Matos
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+ * following disclaimer in the documentation and/or other materials provided with the distribution.
+ *   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifndef USE_USBCON
+#include <utils/ringbuf.h>
+
+tRingBufObject rxBuffer;
+tRingBufObject txBuffer;
+#endif
+
+volatile uint32_t g_ui32milliseconds = 0;
+volatile uint32_t g_ui32heartbeat = 0;

--- a/rosserial_tivac/src/ros_lib/tivac_hardware.h
+++ b/rosserial_tivac/src/ros_lib/tivac_hardware.h
@@ -39,8 +39,10 @@
 #include <stdint.h>
 extern "C"
 {
+  #include <inc/hw_types.h>
   #include <inc/hw_memmap.h>
   #include <inc/hw_ints.h>
+  #include <driverlib/sysctl.h>
   #include <driverlib/gpio.h>
   #include <driverlib/rom.h>
   #include <driverlib/rom_map.h>

--- a/rosserial_tivac/src/ros_lib/tivac_hardware.h
+++ b/rosserial_tivac/src/ros_lib/tivac_hardware.h
@@ -151,9 +151,16 @@ class TivaCHardware
     // write data to the connection to ROS
     void write(uint8_t* data, int length)
     {
-      RingBufWrite(&txBuffer, data, length);
-      // Trigger sending buffer
-      MAP_UARTCharPutNonBlocking(UART0_BASE, RingBufReadOne(&txBuffer));
+      // Trigger sending buffer, if not already sending
+      if (RingBufEmpty(&txBuffer))
+      {
+        RingBufWrite(&txBuffer, data, length);
+        MAP_UARTCharPutNonBlocking(UART0_BASE, RingBufReadOne(&txBuffer));
+      }
+      else
+      {
+        RingBufWrite(&txBuffer, data, length);
+      }        
     }
 
     // returns milliseconds since start of program

--- a/rosserial_tivac/src/ros_lib/tivac_hardware_usb.h
+++ b/rosserial_tivac/src/ros_lib/tivac_hardware_usb.h
@@ -39,8 +39,10 @@
 #include <stdint.h>
 extern "C"
 {
+  #include <inc/hw_types.h>
   #include <inc/hw_memmap.h>
   #include <inc/hw_ints.h>
+  #include <driverlib/sysctl.h>
   #include <driverlib/gpio.h>
   #include <driverlib/rom.h>
   #include <driverlib/rom_map.h>

--- a/rosserial_tivac/src/ros_lib/tivac_hardware_usb.h
+++ b/rosserial_tivac/src/ros_lib/tivac_hardware_usb.h
@@ -2,26 +2,26 @@
  * Copyright (c) 2015, Robosavvy Ltd.
  * All rights reserved.
  * Author: Vitor Matos
- * 
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the 
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
  * following conditions are met:
- * 
- *   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the 
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
  * following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the 
+ *   2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
  * following disclaimer in the documentation and/or other materials provided with the distribution.
- *   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote 
+ *   3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
  * products derived from this software without specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED 
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
- * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY 
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 //*****************************************************************************
 //
 // Bare minimum hardware resources allocated for rosserials communication.
@@ -35,6 +35,8 @@
 #ifndef ROS_LIB_TIVAC_HARDWARE_USB_H
 #define ROS_LIB_TIVAC_HARDWARE_USB_H
 
+#include <stdbool.h>
+#include <stdint.h>
 extern "C"
 {
   #include <inc/hw_memmap.h>
@@ -72,6 +74,9 @@ extern "C"
 #endif
 #endif
 
+extern volatile uint32_t g_ui32milliseconds;
+extern volatile uint32_t g_ui32heartbeat;
+
 class TivaCHardware
 {
   public:
@@ -80,10 +85,10 @@ class TivaCHardware
     void init()
     {
 #ifdef TARGET_IS_TM4C123_RA1
-      TivaCHardware::ui32SysClkFreq = MAP_SysCtlClockGet();
+      this->ui32SysClkFreq = MAP_SysCtlClockGet();
 #endif
 #ifdef TARGET_IS_TM4C129_RA0
-      TivaCHardware::ui32SysClkFreq = TM4C129FREQ;
+      this->ui32SysClkFreq = TM4C129FREQ;
 #endif
 
       // Setup LEDs
@@ -98,10 +103,10 @@ class TivaCHardware
 #endif
 
       // Enable time keeping
-      TivaCHardware::milliseconds = 0;
+      g_ui32milliseconds = 0;
       // Set up timer such that it produces one tick for each millisecond
       SysTickIntRegister(TivaCHardware::SystickIntHandler);
-      MAP_SysTickPeriodSet(TivaCHardware::ui32SysClkFreq/SYSTICKHZ);
+      MAP_SysTickPeriodSet(this->ui32SysClkFreq/SYSTICKHZ);
       MAP_SysTickEnable();
       MAP_SysTickIntEnable();
 
@@ -165,42 +170,39 @@ class TivaCHardware
     // returns milliseconds since start of program
     uint32_t time()
     {
-      return TivaCHardware::milliseconds;
+      return g_ui32milliseconds;
     }
 
     // Timing variables and System Tick interrupt handler.
-    static volatile uint32_t milliseconds;
-    static volatile uint32_t heartbeat;
     static void SystickIntHandler()
     {
-      ++TivaCHardware::milliseconds;
+      ++g_ui32milliseconds;
 #ifdef LED_HEARTBEAT
-      if (++TivaCHardware::heartbeat >= SYSTICKHZ)
+      if (++g_ui32heartbeat >= SYSTICKHZ)
       {
         MAP_GPIOPinWrite(LED_PORT, LED1, MAP_GPIOPinRead(LED_PORT, LED1)^LED1);
-        TivaCHardware::heartbeat = 0;
+        g_ui32heartbeat = 0;
       }
 #endif
     }
 
-    static uint32_t ui32SysClkFreq;
+    // System frequency
+    uint32_t ui32SysClkFreq;
+    uint32_t getSysClkFreq(void)
+    {
+      return this->ui32SysClkFreq;
+    }
+
+    // Not really accurate ms delay. But good enough for our purposes.
+    // For a more elaborate delay check out ``Energia/hardware/lm4f/cores/lm4f/wiring.c``
+    void delay(uint32_t ms)
+    {
+      while (ms > 500)
+      {
+        MAP_SysCtlDelay(this->ui32SysClkFreq/3/SYSTICKHZ * 500);
+        ms -= 500;
+      }
+      MAP_SysCtlDelay(this->ui32SysClkFreq/3/SYSTICKHZ * ms);
+    }
 };
-
-// Static class members
-volatile uint32_t TivaCHardware::milliseconds = 0;
-volatile uint32_t TivaCHardware::heartbeat = 0;
-uint32_t TivaCHardware::ui32SysClkFreq;
-
-// Not really accurate ms delay. But good enough for our purposes.
-// For a more elaborate delay check out ``Energia/hardware/lm4f/cores/lm4f/wiring.c``
-void delay(uint32_t ms)
-{
-  while (ms > 500)
-  {
-    MAP_SysCtlDelay(TivaCHardware::ui32SysClkFreq/3/SYSTICKHZ * 500);
-    ms -= 500;
-  }
-  MAP_SysCtlDelay(TivaCHardware::ui32SysClkFreq/3/SYSTICKHZ * ms);
-}
-
 #endif  // ROS_LIB_TIVAC_HARDWARE_USB_H

--- a/rosserial_tivac/tivac-cmake/cmake/TivaCToolchain.cmake
+++ b/rosserial_tivac/tivac-cmake/cmake/TivaCToolchain.cmake
@@ -166,6 +166,7 @@ function(GENERATE_TIVAC_FIRMWARE)
     ${TIVA_WARE_PATH}/utils/ringbuf.c
     ${ROS_LIB_DIR}/duration.cpp 
     ${ROS_LIB_DIR}/time.cpp
+    ${ROS_LIB_DIR}/tivac_hardware.cpp
     ${OTHER_SRCS}
   )
   target_link_libraries(${CMAKE_PROJECT_NAME}.axf 


### PR DESCRIPTION
When developing a tutorial case for [FreeRTOS+rosserial_tivac](https://github.com/robosavvy/rosserial_tivac_tutorials/tree/master/freertos123) I encountered an error when someone includes ros.h on multiple files, gets multiple instantiations of the static members.

Solution:
Removing the variables which need instantiation for being used by the Class static functions, from the header onto its own source file.
