### PR TITLE
[rosserial_server] Support for service servers

### DIFF
--- a/rosserial_server/include/rosserial_server/session.h
+++ b/rosserial_server/include/rosserial_server/session.h
@@ -354,7 +354,7 @@ private:
   template<typename M>
   bool check_set(std::string param_name, M map) {
     XmlRpc::XmlRpcValue param_list;
-    ros::param::get(param_name, param_list);
+    if(!ros::param::get(param_name, param_list)) return true;
     ROS_ASSERT(param_list.getType() == XmlRpc::XmlRpcValue::TypeArray);
     for (int i = 0; i < param_list.size(); ++i) {
       ROS_ASSERT(param_list[i].getType() == XmlRpc::XmlRpcValue::TypeString);

--- a/rosserial_server/include/rosserial_server/session.h
+++ b/rosserial_server/include/rosserial_server/session.h
@@ -342,8 +342,10 @@ private:
   void required_topics_check(const boost::system::error_code& error) {
     if (ros::param::has("~require")) {
       if (!check_set("~require/publishers", publishers_) ||
-          !check_set("~require/subscribers", subscribers_)) {
-        ROS_WARN("Connected client failed to establish the publishers and subscribers dictated by require parameter. Re-requesting topics.");
+          !check_set("~require/subscribers", subscribers_) ||
+          !check_set("~require/service_clients", service_clients_) ||
+          !check_set("~require/service_servers", service_servers_)) {
+        ROS_WARN("Connected client failed to establish the interfaces dictated by require parameter. Re-requesting.");
         request_topics();
       }
     }
@@ -356,12 +358,12 @@ private:
     ROS_ASSERT(param_list.getType() == XmlRpc::XmlRpcValue::TypeArray);
     for (int i = 0; i < param_list.size(); ++i) {
       ROS_ASSERT(param_list[i].getType() == XmlRpc::XmlRpcValue::TypeString);
-      std::string required_topic((std::string(param_list[i])));
-      // Iterate through map of registered topics, to ensure that this one is present.
+      std::string required_name((std::string(param_list[i])));
+      // Iterate through map of registered names, to ensure that this one is present.
       bool found = false;
       for (typename M::iterator j = map.begin(); j != map.end(); ++j) {
-        if (nh_.resolveName(j->second->get_topic()) ==
-            nh_.resolveName(required_topic)) {
+        if (nh_.resolveName(j->second->get_name()) ==
+            nh_.resolveName(required_name)) {
           found = true;
           break;
         }

--- a/rosserial_server/include/rosserial_server/session.h
+++ b/rosserial_server/include/rosserial_server/session.h
@@ -78,12 +78,17 @@ public:
         = boost::bind(&Session::setup_service_client_publisher, this, _1);
     callbacks_[rosserial_msgs::TopicInfo::ID_SERVICE_CLIENT+rosserial_msgs::TopicInfo::ID_SUBSCRIBER]
         = boost::bind(&Session::setup_service_client_subscriber, this, _1);
+    callbacks_[rosserial_msgs::TopicInfo::ID_SERVICE_SERVER+rosserial_msgs::TopicInfo::ID_PUBLISHER]
+        = boost::bind(&Session::setup_service_server_publisher, this, _1);
+    callbacks_[rosserial_msgs::TopicInfo::ID_SERVICE_SERVER+rosserial_msgs::TopicInfo::ID_SUBSCRIBER]
+        = boost::bind(&Session::setup_service_server_subscriber, this, _1);
     callbacks_[rosserial_msgs::TopicInfo::ID_TIME]
         = boost::bind(&Session::handle_time, this, _1);
   }
 
   virtual ~Session()
   {
+    abort_servers();
     ROS_INFO("Ending session.");
   }
 
@@ -294,11 +299,17 @@ private:
           boost::asio::placeholders::error));
   }
 
+  void abort_servers() {
+    for(std::map<std::string, ServiceServerPtr>::iterator it = service_servers_.begin(); it != service_servers_.end(); ++it)
+        it->second->abort();
+  }
+
   void sync_timeout(const boost::system::error_code& error) {
     if (error == boost::asio::error::operation_aborted) {
       return;
     }
     ROS_WARN("Sync with device lost.");
+    abort_servers();
     attempt_sync();
   }
 
@@ -406,14 +417,14 @@ private:
     rosserial_msgs::TopicInfo topic_info;
     ros::serialization::Serializer<rosserial_msgs::TopicInfo>::read(stream, topic_info);
 
-    if (!services_.count(topic_info.topic_name)) {
+    if (!service_clients_.count(topic_info.topic_name)) {
       ROS_DEBUG("Creating service client for topic %s",topic_info.topic_name.c_str());
       ServiceClientPtr srv(new ServiceClient(
         nh_,topic_info,boost::bind(&Session::write_message, this, _1, _2, client_version)));
-      services_[topic_info.topic_name] = srv;
+      service_clients_[topic_info.topic_name] = srv;
       callbacks_[topic_info.topic_id] = boost::bind(&ServiceClient::handle, srv, _1);
     }
-    if (services_[topic_info.topic_name]->getRequestMessageMD5() != topic_info.md5sum) {
+    if (service_clients_[topic_info.topic_name]->getRequestMessageMD5() != topic_info.md5sum) {
       ROS_WARN("Service client setup: Request message MD5 mismatch between rosserial client and ROS");
     } else {
       ROS_DEBUG("Service client %s: request message MD5 successfully validated as %s",
@@ -426,16 +437,16 @@ private:
     rosserial_msgs::TopicInfo topic_info;
     ros::serialization::Serializer<rosserial_msgs::TopicInfo>::read(stream, topic_info);
 
-    if (!services_.count(topic_info.topic_name)) {
+    if (!service_clients_.count(topic_info.topic_name)) {
       ROS_DEBUG("Creating service client for topic %s",topic_info.topic_name.c_str());
       ServiceClientPtr srv(new ServiceClient(
         nh_,topic_info,boost::bind(&Session::write_message, this, _1, _2, client_version)));
-      services_[topic_info.topic_name] = srv;
+      service_clients_[topic_info.topic_name] = srv;
       callbacks_[topic_info.topic_id] = boost::bind(&ServiceClient::handle, srv, _1);
     }
     // see above comment regarding the service client callback for why we set topic_id here
-    services_[topic_info.topic_name]->setTopicId(topic_info.topic_id);
-    if (services_[topic_info.topic_name]->getResponseMessageMD5() != topic_info.md5sum) {
+    service_clients_[topic_info.topic_name]->setTopicId(topic_info.topic_id);
+    if (service_clients_[topic_info.topic_name]->getResponseMessageMD5() != topic_info.md5sum) {
       ROS_WARN("Service client setup: Response message MD5 mismatch between rosserial client and ROS");
     } else {
       ROS_DEBUG("Service client %s: response message MD5 successfully validated as %s",
@@ -443,6 +454,48 @@ private:
     }
     set_sync_timeout(timeout_interval_);
   }
+
+  void setup_service_server_publisher(ros::serialization::IStream& stream) {
+    rosserial_msgs::TopicInfo topic_info;
+    ros::serialization::Serializer<rosserial_msgs::TopicInfo>::read(stream, topic_info);
+
+    if (!service_servers_.count(topic_info.topic_name)) {
+      ROS_DEBUG("Creating service server for topic %s",topic_info.topic_name.c_str());
+      ServiceServerPtr srv(new ServiceServer(
+        nh_,topic_info,boost::bind(&Session::write_message, this, _1, _2, client_version)));
+      service_servers_[topic_info.topic_name] = srv;
+      callbacks_[topic_info.topic_id] = boost::bind(&ServiceServer::handle, srv, _1);
+    }
+    if (service_servers_[topic_info.topic_name]->getResponseMessageMD5() != topic_info.md5sum) {
+      ROS_WARN("Service client setup: Response message MD5 mismatch between rosserial client and ROS");
+    } else {
+      ROS_DEBUG("Service client %s: request message MD5 successfully validated as %s",
+        topic_info.topic_name.c_str(),topic_info.md5sum.c_str());
+    }
+    set_sync_timeout(timeout_interval_);
+  }
+
+  void setup_service_server_subscriber(ros::serialization::IStream& stream) {
+    rosserial_msgs::TopicInfo topic_info;
+    ros::serialization::Serializer<rosserial_msgs::TopicInfo>::read(stream, topic_info);
+
+    if (!service_servers_.count(topic_info.topic_name)) {
+      ROS_DEBUG("Creating service client for topic %s",topic_info.topic_name.c_str());
+      ServiceServerPtr srv(new ServiceServer(
+        nh_,topic_info,boost::bind(&Session::write_message, this, _1, _2, client_version)));
+      service_servers_[topic_info.topic_name] = srv;
+      callbacks_[topic_info.topic_id] = boost::bind(&ServiceServer::handle, srv, _1);
+    }
+    service_servers_[topic_info.topic_name]->setTopicId(topic_info.topic_id);
+    if (service_servers_[topic_info.topic_name]->getRequestMessageMD5() != topic_info.md5sum) {
+      ROS_WARN("Service client setup: Request message MD5 mismatch between rosserial client and ROS");
+    } else {
+      ROS_DEBUG("Service client %s: request message MD5 successfully validated as %s",
+        topic_info.topic_name.c_str(),topic_info.md5sum.c_str());
+    }
+    set_sync_timeout(timeout_interval_);
+  }
+
 
   void handle_time(ros::serialization::IStream& stream) {
     std_msgs::Time time;
@@ -477,7 +530,8 @@ private:
   std::map< uint16_t, boost::function<void(ros::serialization::IStream)> > callbacks_;
   std::map<uint16_t, PublisherPtr> publishers_;
   std::map<uint16_t, SubscriberPtr> subscribers_;
-  std::map<std::string, ServiceClientPtr> services_;
+  std::map<std::string, ServiceClientPtr> service_clients_;
+  std::map<std::string, ServiceServerPtr> service_servers_;
 };
 
 }  // namespace

--- a/rosserial_server/include/rosserial_server/topic_handlers.h
+++ b/rosserial_server/include/rosserial_server/topic_handlers.h
@@ -75,7 +75,10 @@ public:
     publisher_.publish(message_);
   }
 
-  std::string get_topic() {
+  ROS_DEPRECATED std::string get_topic() {
+      return get_name();
+  }
+  std::string get_name() {
     return publisher_.getTopic();
   }
 
@@ -103,7 +106,10 @@ public:
     subscriber_ = nh.subscribe(opts);
   }
 
-  std::string get_topic() {
+  ROS_DEPRECATED std::string get_topic() {
+      return get_name();
+  }
+  std::string get_name() {
     return subscriber_.getTopic();
   }
 
@@ -178,6 +184,10 @@ public:
     ros::serialization::OStream ostream(&buffer[0], length);
     ros::serialization::Serializer<topic_tools::ShapeShifter>::write(ostream, response_message_);
     write_fn_(buffer,topic_id_);
+  }
+
+  std::string get_name() {
+    return service_client_.getService();
   }
 
 private:

--- a/rosserial_server/include/rosserial_server/topic_handlers.h
+++ b/rosserial_server/include/rosserial_server/topic_handlers.h
@@ -195,6 +195,116 @@ private:
 ros::ServiceClient ServiceClient::service_info_service_;
 typedef boost::shared_ptr<ServiceClient> ServiceClientPtr;
 
+class ServiceServer {
+  class ServiceCallbackHelper : public ros::ServiceCallbackHelper {
+    boost::function<void(std::vector<uint8_t> buffer, const uint16_t topic_id)> write_fn_;
+    uint16_t topic_id_;
+    int got_response_;
+    boost::mutex mutex_;
+    boost::condition_variable cond_;
+    topic_tools::ShapeShifter response_message_;
+ public:
+    ServiceCallbackHelper(boost::function<void(std::vector<uint8_t> buffer, const uint16_t topic_id)> write_fn):
+    write_fn_(write_fn), topic_id_(-1) {}
+    virtual bool call(ros::ServiceCallbackHelperCallParams& params){
+      std::vector<uint8_t> buffer(params.request.message_start, params.request.message_start + params.request.num_bytes);
+
+      boost::mutex::scoped_lock lock(mutex_);
+      got_response_ = 0;
+      write_fn_(buffer,topic_id_);
+
+      while (!got_response_){
+          cond_.wait(lock);
+      }
+
+      if(got_response_ == 1) {
+        params.response = ros::serialization::serializeServiceResponse(true, response_message_);
+        return true;
+      }
+      return false;
+    }
+    void handle(ros::serialization::IStream stream) {
+      ros::serialization::Serializer<topic_tools::ShapeShifter>::read(stream, response_message_);
+      boost::mutex::scoped_lock lock(mutex_);
+      got_response_ = 1;
+      cond_.notify_all();
+    }
+
+    void abort() {
+      boost::mutex::scoped_lock lock(mutex_);
+      got_response_ = -1;
+      cond_.notify_all();
+    }
+
+    void setTopicId(uint16_t topic_id) {
+        topic_id_ = topic_id;
+    }
+  };
+public:
+  ServiceServer(ros::NodeHandle& nh, rosserial_msgs::TopicInfo& topic_info,
+      boost::function<void(std::vector<uint8_t> buffer, const uint16_t topic_id)> write_fn)
+  {
+    if (!service_info_service_.isValid()) {
+      // lazy-initialize the service caller.
+      service_info_service_ = nh.serviceClient<rosserial_msgs::RequestServiceInfo>("service_info");
+      if (!service_info_service_.waitForExistence(ros::Duration(5.0))) {
+        ROS_WARN("Timed out waiting for service_info service to become available.");
+      }
+    }
+
+    rosserial_msgs::RequestServiceInfo info;
+    info.request.service = topic_info.message_type;
+    ROS_DEBUG("Calling service_info service for topic name %s",topic_info.topic_name.c_str());
+    if (service_info_service_.call(info)) {
+      request_message_md5_ = info.response.request_md5;
+      response_message_md5_ = info.response.response_md5;
+    } else {
+      ROS_WARN("Failed to call service_info service. The service client will be created with blank md5sum.");
+    }
+
+    ros::AdvertiseServiceOptions opts;
+    opts.service = topic_info.topic_name;
+    opts.md5sum = info.response.service_md5;
+    opts.datatype = topic_info.message_type;
+    opts.req_datatype = request_message_md5_;
+    opts.res_datatype = response_message_md5_;
+
+    service_call_helper_.reset(new ServiceCallbackHelper(write_fn));
+    opts.helper = service_call_helper_;
+
+    service_server_ = nh.advertiseService(opts);
+  }
+  void setTopicId(uint16_t topic_id) {
+    service_call_helper_->setTopicId(topic_id);
+  }
+  std::string getRequestMessageMD5() {
+    return request_message_md5_;
+  }
+  std::string getResponseMessageMD5() {
+    return response_message_md5_;
+  }
+  void handle(ros::serialization::IStream stream) {
+    service_call_helper_->handle(stream);
+  }
+  void abort() {
+    service_call_helper_->abort();
+  }
+  std::string get_name() {
+    return service_server_.getService();
+  }
+
+private:
+  ros::ServiceServer service_server_;
+  static ros::ServiceClient service_info_service_;
+  boost::shared_ptr<ServiceCallbackHelper> service_call_helper_;
+  std::string request_message_md5_;
+  std::string response_message_md5_;
+};
+
+ros::ServiceClient ServiceServer::service_info_service_;
+typedef boost::shared_ptr<ServiceServer> ServiceServerPtr;
+
+
 }  // namespace
 
 #endif  // ROSSERIAL_SERVER_TOPIC_HANDLERS_H


### PR DESCRIPTION
Addresses #175 
Since this implementation uses condition variables I have added an abort_servers() member that aborts all running service calls in case of lost syncs and shutdown.

In addition I have added `require/service_clients` and `require/service_servers` handling.
To not break any existing installations lists that are not provided are skipped.
