### PR TITLE
Add ros.h include to transform_broadcaster

### DIFF
--- a/rosserial_arduino/arduino-cmake/cmake/ArduinoToolchain.cmake
+++ b/rosserial_arduino/arduino-cmake/cmake/ArduinoToolchain.cmake
@@ -71,7 +71,7 @@ find_path(ARDUINO_SDK_PATH
           PATH_SUFFIXES share/arduino
                         Arduino.app/Contents/Resources/Java/
                         ${ARDUINO_PATHS}
-          HINTS ${SDK_PATH_HINTS}
+                        HINTS ${SDK_PATH_HINTS} ENV arduino_location_cmake
           DOC "Arduino SDK path.")
 
 if(ARDUINO_SDK_PATH)

--- a/rosserial_client/src/ros_lib/tf/transform_broadcaster.h
+++ b/rosserial_client/src/ros_lib/tf/transform_broadcaster.h
@@ -35,6 +35,7 @@
 #ifndef ROS_TRANSFORM_BROADCASTER_H_
 #define ROS_TRANSFORM_BROADCASTER_H_
 
+#include "ros.h"
 #include "tfMessage.h"
 
 namespace tf


### PR DESCRIPTION
Inline implementation requires the ros.h header to give proper access to the NodeHandle.

```
/var/lib/jenkins/workspace/rover_all/catkin_ws/build/arduino/ros_lib/tf/transform_broadcaster.h:48:22: error: ‘ros::NodeHandle’ has not been declared
       void init(ros::NodeHandle &nh)
                      ^
/var/lib/jenkins/workspace/rover_all/catkin_ws/build/arduino/ros_lib/tf/transform_broadcaster.h:62:7: error: ‘Publisher’ in namespace ‘ros’ does not name a type
       ros::Publisher publisher_;
       ^
```
