### PR TITLE
Implementation of native UDP rosserial server.

### DIFF
--- a/rosserial_server/CMakeLists.txt
+++ b/rosserial_server/CMakeLists.txt
@@ -25,6 +25,11 @@ target_link_libraries(${PROJECT_NAME}_socket_node ${catkin_LIBRARIES})
 set_target_properties(${PROJECT_NAME}_socket_node PROPERTIES OUTPUT_NAME socket_node PREFIX "")
 add_dependencies(${PROJECT_NAME}_socket_node rosserial_msgs_gencpp)
 
+add_executable(${PROJECT_NAME}_udp_socket_node src/udp_socket_node.cpp)
+target_link_libraries(${PROJECT_NAME}_udp_socket_node ${catkin_LIBRARIES})
+set_target_properties(${PROJECT_NAME}_udp_socket_node PROPERTIES OUTPUT_NAME udp_socket_node PREFIX "")
+add_dependencies(${PROJECT_NAME}_udp_socket_node rosserial_msgs_gencpp)
+
 install(
   TARGETS ${PROJECT_NAME}_socket_node ${PROJECT_NAME}_serial_node
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/rosserial_server/include/rosserial_server/udp_socket_session.h
+++ b/rosserial_server/include/rosserial_server/udp_socket_session.h
@@ -1,0 +1,90 @@
+/**
+ *
+ *  \file
+ *  \brief      Reconnecting class for a UDP rosserial session.
+ *  \author     Mike Purvis <mpurvis@clearpathrobotics.com>
+ *  \copyright  Copyright (c) 2016, Clearpath Robotics, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Clearpath Robotics, Inc. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Please send comments, questions, or patches to code@clearpathrobotics.com
+ *
+ */
+
+#ifndef ROSSERIAL_SERVER_UDP_SOCKET_SESSION_H
+#define ROSSERIAL_SERVER_UDP_SOCKET_SESSION_H
+
+#include <iostream>
+#include <boost/bind.hpp>
+#include <boost/asio.hpp>
+
+#include <ros/ros.h>
+
+#include "rosserial_server/session.h"
+#include "rosserial_server/udp_stream.h"
+
+
+namespace rosserial_server
+{
+
+using boost::asio::ip::udp;
+
+class UdpSocketSession : public Session<UdpStream>
+{
+public:
+  UdpSocketSession(boost::asio::io_service& io_service,
+                   udp::endpoint server_endpoint,
+                   udp::endpoint client_endpoint)
+    : Session(io_service), timer_(io_service),
+      server_endpoint_(server_endpoint), client_endpoint_(client_endpoint)
+  {
+    ROS_INFO_STREAM("rosserial_server UDP session created between " << server_endpoint << " and " << client_endpoint);
+    check_connection();
+  }
+
+private:
+  void check_connection()
+  {
+    if (!is_active())
+    {
+      socket().open(server_endpoint_, client_endpoint_);
+      start();
+    }
+
+    // Every second, check again if the connection should be reinitialized,
+    // if the ROS node is still up.
+    if (ros::ok())
+    {
+      timer_.expires_from_now(boost::posix_time::milliseconds(1000));
+      timer_.async_wait(boost::bind(&UdpSocketSession::check_connection, this));
+    }
+  }
+
+  boost::asio::deadline_timer timer_;
+  udp::endpoint server_endpoint_;
+  udp::endpoint client_endpoint_;
+};
+
+}  // namespace
+
+#endif  // ROSSERIAL_SERVER_UDP_SOCKET_SESSION_H

--- a/rosserial_server/include/rosserial_server/udp_stream.h
+++ b/rosserial_server/include/rosserial_server/udp_stream.h
@@ -1,0 +1,109 @@
+/**
+ *
+ *  \file
+ *  \brief      Adapter which allows a single-ended UDP connection to
+ *              present the stream interface.
+ *  \author     Mike Purvis <mpurvis@clearpathrobotics.com>
+ *  \copyright  Copyright (c) 2016, Clearpath Robotics, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Clearpath Robotics, Inc. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Please send comments, questions, or patches to code@clearpathrobotics.com
+ *
+ */
+
+#ifndef ROSSERIAL_SERVER_UDP_STREAM_H
+#define ROSSERIAL_SERVER_UDP_STREAM_H
+
+#include <iostream>
+#include <boost/bind.hpp>
+#include <boost/asio.hpp>
+
+#include <ros/ros.h>
+
+#include "rosserial_server/session.h"
+
+
+namespace rosserial_server
+{
+
+using boost::asio::ip::udp;
+using boost::asio::handler_type;
+
+
+class UdpStream : public udp::socket
+{
+public:
+  explicit UdpStream(boost::asio::io_service& io_service) : udp::socket(io_service)
+  {
+  }
+
+  void open(udp::endpoint server_endpoint, udp::endpoint client_endpoint)
+  {
+    boost::system::error_code ec;
+    const protocol_type protocol = server_endpoint.protocol();
+    this->get_service().open(this->get_implementation(), protocol, ec);
+    boost::asio::detail::throw_error(ec, "open");
+    this->get_service().bind(this->get_implementation(), server_endpoint, ec);
+    boost::asio::detail::throw_error(ec, "bind");
+
+    client_endpoint_ = client_endpoint;
+  }
+
+  template <typename ConstBufferSequence, typename WriteHandler>
+  BOOST_ASIO_INITFN_RESULT_TYPE(WriteHandler,
+      void (boost::system::error_code, std::size_t))
+  async_write_some(const ConstBufferSequence& buffers,
+      BOOST_ASIO_MOVE_ARG(WriteHandler) handler)
+  {
+    // If you get an error on the following line it means that your handler does
+    // not meet the documented type requirements for a WriteHandler.
+    BOOST_ASIO_WRITE_HANDLER_CHECK(WriteHandler, handler) type_check;
+
+    return this->get_service().async_send_to(
+        this->get_implementation(), buffers, client_endpoint_, 0,
+        BOOST_ASIO_MOVE_CAST(WriteHandler)(handler));
+  }
+
+  template <typename MutableBufferSequence, typename ReadHandler>
+  BOOST_ASIO_INITFN_RESULT_TYPE(ReadHandler,
+      void (boost::system::error_code, std::size_t))
+  async_read_some(const MutableBufferSequence& buffers,
+      BOOST_ASIO_MOVE_ARG(ReadHandler) handler)
+  {
+    // If you get an error on the following line it means that your handler does
+    // not meet the documented type requirements for a ReadHandler.
+    BOOST_ASIO_READ_HANDLER_CHECK(ReadHandler, handler) type_check;
+
+    return this->get_service().async_receive_from(
+        this->get_implementation(), buffers, client_endpoint_, 0,
+        BOOST_ASIO_MOVE_CAST(ReadHandler)(handler));
+  }
+
+private:
+  udp::endpoint client_endpoint_;
+};
+
+}  // namespace
+
+#endif  // ROSSERIAL_SERVER_UDP_STREAM_H

--- a/rosserial_server/launch/udp_socket.launch
+++ b/rosserial_server/launch/udp_socket.launch
@@ -1,0 +1,10 @@
+<launch>
+  <arg name="port" default="11411" />
+  <arg name="addr" default="127.0.0.1" />
+
+  <node pkg="rosserial_server" type="udp_socket_node" name="rosserial_server">
+    <param name="client_port" value="$(arg port)" />
+    <param name="client_addr" value="$(arg addr)" />
+  </node>
+  <node pkg="rosserial_python" type="message_info_service.py" name="rosserial_message_info" />
+</launch>

--- a/rosserial_server/src/udp_socket_node.cpp
+++ b/rosserial_server/src/udp_socket_node.cpp
@@ -1,0 +1,65 @@
+/**
+ *
+ *  \file
+ *  \brief      Main entry point for the UDP socket server node.
+ *  \author     Mike Purvis <mpurvis@clearpathrobotics.com>
+ *  \copyright  Copyright (c) 2016, Clearpath Robotics, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Clearpath Robotics, Inc. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL CLEARPATH ROBOTICS, INC. BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Please send comments, questions, or patches to code@clearpathrobotics.com
+ *
+ */
+
+#include <boost/asio.hpp>
+#include <boost/bind.hpp>
+#include <boost/thread.hpp>
+
+#include <ros/ros.h>
+
+#include "rosserial_server/udp_socket_session.h"
+
+using boost::asio::ip::udp;
+using boost::asio::ip::address;
+
+
+int main(int argc, char* argv[])
+{
+  ros::init(argc, argv, "rosserial_server_udp_socket_node");
+
+  int server_port;
+  int client_port;
+  std::string client_addr;
+  ros::param::param<int>("~server_port", server_port, 11411);
+  ros::param::param<int>("~client_port", client_port, 11411);
+  ros::param::param<std::string>("~client_addr", client_addr, "127.0.0.1");
+
+  boost::asio::io_service io_service;
+  rosserial_server::UdpSocketSession udp_socket_session(
+      io_service,
+      udp::endpoint(udp::v4(), server_port),
+      udp::endpoint(address::from_string(client_addr), client_port));
+  io_service.run();
+
+  return 0;
+}


### PR DESCRIPTION
We use rosserial-over-UDP on Ridgeback, which is currently managed by a background socat instance which presents the UDP messages as a tty, which we then run the serial rosserial_server against (see [invocation here](https://github.com/ridgeback/ridgeback_robot/blob/97ba2d02b2972d83628dea79a19e10453255e7d0/ridgeback_bringup/scripts/can-udp-bridge.conf#L18)).

This change allows rosserial_server to do this natively, without depending on a secondary process.

@mikeodr @tonybaltovski
