### PR TITLE
Fix #109

### DIFF
--- a/rosserial_client/src/ros_lib/ros/msg.h
+++ b/rosserial_client/src/ros_lib/ros/msg.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Willow Garage, Inc.
@@ -114,12 +114,27 @@ public:
     if (exp != 0)
     {
       *val |= ((exp) - 1023 + 127) << 23;
-    }  
+    }
 
     // Copy negative sign.
     *val |= ((uint32_t)(*(inbuffer++)) & 0x80) << 24;
 
     return 8;
+  }
+
+  template<typename A, typename V>
+  static void varToArr(A arr, const V var)
+  {
+    for(size_t i = 0; i < sizeof(V); i++)
+      arr[i] = (var >> (8 * i));
+  }
+
+  template<typename V, typename A>
+  static void arrToVar(V& var, const A arr)
+  {
+    var = 0;
+    for(size_t i = 0; i < sizeof(V); i++)
+      var |= (arr[i] << (8 * i));
   }
 
 };

--- a/rosserial_client/src/ros_lib/ros/msg.h
+++ b/rosserial_client/src/ros_lib/ros/msg.h
@@ -36,6 +36,7 @@
 #define _ROS_MSG_H_
 
 #include <stdint.h>
+#include <stddef.h>
 
 namespace ros {
 
@@ -122,6 +123,7 @@ public:
     return 8;
   }
 
+  // Copy data from variable into a byte array
   template<typename A, typename V>
   static void varToArr(A arr, const V var)
   {
@@ -129,6 +131,7 @@ public:
       arr[i] = (var >> (8 * i));
   }
 
+  // Copy data from a byte array into variable
   template<typename V, typename A>
   static void arrToVar(V& var, const A arr)
   {

--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -160,7 +160,7 @@ class StringDataType(PrimitiveDataType):
     def serialize(self, f):
         cn = self.name.replace("[","").replace("]","")
         f.write('      uint32_t length_%s = strlen(this->%s);\n' % (cn,self.name))
-        f.write('      memcpy(outbuffer + offset, &length_%s, sizeof(uint32_t));\n' % cn)
+        f.write('      varToArr(outbuffer + offset, length_%s);\n' % cn)
         f.write('      offset += 4;\n')
         f.write('      memcpy(outbuffer + offset, this->%s, length_%s);\n' % (self.name,cn))
         f.write('      offset += length_%s;\n' % cn)
@@ -168,7 +168,7 @@ class StringDataType(PrimitiveDataType):
     def deserialize(self, f):
         cn = self.name.replace("[","").replace("]","")
         f.write('      uint32_t length_%s;\n' % cn)
-        f.write('      memcpy(&length_%s, (inbuffer + offset), sizeof(uint32_t));\n' % cn)
+        f.write('      arrToVar(length_%s, (inbuffer + offset));\n' % cn)
         f.write('      offset += 4;\n')
         f.write('      for(unsigned int k= offset; k< offset+length_%s; ++k){\n'%cn) #shift for null character
         f.write('          inbuffer[k-1]=inbuffer[k];\n')


### PR DESCRIPTION
Replaced the function memcpy on a universal (little-endian/big-endian) functions varToArr and arrToVar
