### PR TITLE
Use catkin_EXPORTED_TARGETS to avoid CMake warning

### DIFF
--- a/rosserial_server/CMakeLists.txt
+++ b/rosserial_server/CMakeLists.txt
@@ -18,17 +18,17 @@ include_directories(
 add_executable(${PROJECT_NAME}_serial_node src/serial_node.cpp)
 target_link_libraries(${PROJECT_NAME}_serial_node ${catkin_LIBRARIES})
 set_target_properties(${PROJECT_NAME}_serial_node PROPERTIES OUTPUT_NAME serial_node PREFIX "")
-add_dependencies(${PROJECT_NAME}_serial_node rosserial_msgs_gencpp)
+add_dependencies(${PROJECT_NAME}_serial_node ${catkin_EXPORTED_TARGETS})
 
 add_executable(${PROJECT_NAME}_socket_node src/socket_node.cpp)
 target_link_libraries(${PROJECT_NAME}_socket_node ${catkin_LIBRARIES})
 set_target_properties(${PROJECT_NAME}_socket_node PROPERTIES OUTPUT_NAME socket_node PREFIX "")
-add_dependencies(${PROJECT_NAME}_socket_node rosserial_msgs_gencpp)
+add_dependencies(${PROJECT_NAME}_socket_node ${catkin_EXPORTED_TARGETS})
 
 add_executable(${PROJECT_NAME}_udp_socket_node src/udp_socket_node.cpp)
 target_link_libraries(${PROJECT_NAME}_udp_socket_node ${catkin_LIBRARIES})
 set_target_properties(${PROJECT_NAME}_udp_socket_node PROPERTIES OUTPUT_NAME udp_socket_node PREFIX "")
-add_dependencies(${PROJECT_NAME}_udp_socket_node rosserial_msgs_gencpp)
+add_dependencies(${PROJECT_NAME}_udp_socket_node ${catkin_EXPORTED_TARGETS})
 
 install(
   TARGETS ${PROJECT_NAME}_serial_node ${PROJECT_NAME}_socket_node  ${PROJECT_NAME}_udp_socket_node

--- a/rosserial_test/CMakeLists.txt
+++ b/rosserial_test/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rosserial_test)
 
-find_package(catkin REQUIRED COMPONENTS roscpp rosserial_client rosserial_python rosserial_server rostest)
+find_package(catkin REQUIRED COMPONENTS roscpp rosserial_client rosserial_msgs rosserial_python rosserial_server rostest std_msgs)
 
 catkin_package()
 
@@ -12,7 +12,7 @@ if(CATKIN_ENABLE_TESTING)
     COMMAND ${CATKIN_DEVEL_PREFIX}/env.sh rosrun rosserial_test generate_client_ros_lib ${PROJECT_BINARY_DIR}/include
   )
   add_custom_target(${PROJECT_NAME}_rosserial_lib DEPENDS ${PROJECT_BINARY_DIR}/include/rosserial)
-  add_dependencies(${PROJECT_NAME}_rosserial_lib std_msgs_genpy rosserial_msgs_genpy)
+  add_dependencies(${PROJECT_NAME}_rosserial_lib ${catkin_EXPORTED_TARGETS})
 
   include_directories(
     include ${PROJECT_BINARY_DIR}/include ${catkin_INCLUDE_DIRS}

--- a/rosserial_test/package.xml
+++ b/rosserial_test/package.xml
@@ -16,7 +16,9 @@
   <depend>roscpp</depend>
   <depend>gtest</depend>
   <depend>rosserial_client</depend>
+  <depend>rosserial_msgs</depend>
   <depend>rosserial_python</depend>
   <depend>rosserial_server</depend>
   <depend>rostest</depend>
+  <depend>std_msgs</depend>
  </package>


### PR DESCRIPTION
Pretty sure I have this right, according to:

http://docs.ros.org/kinetic/api/catkin/html/howto/format2/cpp_msg_dependencies.html
