### PR TITLE
Missing 'h' inside constructor ArduinoHardware(ArduinoHardware& h)

### DIFF
--- a/rosserial_arduino/src/ros_lib/ArduinoHardware.h
+++ b/rosserial_arduino/src/ros_lib/ArduinoHardware.h
@@ -78,7 +78,7 @@ class ArduinoHardware {
       baud_ = 57600;
     }
     ArduinoHardware(ArduinoHardware& h){
-      this->iostream = iostream;
+      this->iostream = h.iostream;
       this->baud_ = h.baud_;
     }
   


### PR DESCRIPTION
There was a missing ArduinoHardware object name 'h' inside the constructor ArduinoHardware(ArduinoHardware& h) at line number 81.
