### PR TITLE
Fix typo in serial error message

### DIFF
--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -413,7 +413,7 @@ class SerialClient:
 
             if bytes_remaining != 0:
                 rospy.logwarn("Serial Port read returned short (expected %d bytes, received %d instead)."
-                              % (length, len(length - bytes_remaining)))
+                              % (length, length - bytes_remaining))
                 raise IOError()
 
             return bytes(result)


### PR DESCRIPTION
`length`  and `bytes_remaining` are integers, and so don't have a `len()`.

Before this fix, when the wrong number of bytes were read over serial, an error about "`int` has no len()` was printed.
