### PR TITLE
Rosserial client var typedef

### DIFF
--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -84,7 +84,7 @@ class PrimitiveDataType:
         f.write('      %s(0)%s\n' % (self.name, trailer))
 
     def make_declaration(self, f):
-        f.write('      %s %s;\n' % (self.type, self.name) )
+        f.write('      typedef %s _%s_type;\n      _%s_type %s;\n' % (self.type, self.name, self.name, self.name) )
 
     def serialize(self, f):
         cn = self.name.replace("[","").replace("]","").split(".")[-1]
@@ -139,7 +139,7 @@ class AVR_Float64DataType(PrimitiveDataType):
         f.write('      %s(0)%s\n' % (self.name, trailer))
 
     def make_declaration(self, f):
-        f.write('      float %s;\n' % self.name )
+        f.write('      typedef float _%s_type;\n      _%s_type %s;\n' % (self.name, self.name, self.name) )
 
     def serialize(self, f):
         f.write('      offset += serializeAvrFloat64(outbuffer + offset, this->%s);\n' % self.name)
@@ -155,7 +155,7 @@ class StringDataType(PrimitiveDataType):
         f.write('      %s("")%s\n' % (self.name, trailer))
 
     def make_declaration(self, f):
-        f.write('      const char* %s;\n' % self.name)
+        f.write('      typedef const char* _%s_type;\n      _%s_type %s;\n' % (self.name, self.name, self.name) )
 
     def serialize(self, f):
         cn = self.name.replace("[","").replace("]","")
@@ -190,7 +190,7 @@ class TimeDataType(PrimitiveDataType):
         f.write('      %s()%s\n' % (self.name, trailer))
 
     def make_declaration(self, f):
-        f.write('      %s %s;\n' % (self.type, self.name))
+        f.write('      typedef %s _%s_type;\n      _%s_type %s;\n' % (self.type, self.name, self.name, self.name) )
 
     def serialize(self, f):
         self.sec.serialize(f)
@@ -220,8 +220,9 @@ class ArrayDataType(PrimitiveDataType):
         c = self.cls("*"+self.name, self.type, self.bytes)
         if self.size == None:
             f.write('      uint32_t %s_length;\n' % self.name)
-            f.write('      %s st_%s;\n' % (self.type, self.name)) # static instance for copy
-            f.write('      %s * %s;\n' % (self.type, self.name))
+            f.write('      typedef %s _%s_type;\n' % (self.type, self.name))
+            f.write('      _%s_type st_%s;\n' % (self.name, self.name)) # static instance for copy
+            f.write('      _%s_type * %s;\n' % (self.name, self.name))
         else:
             f.write('      %s %s[%d];\n' % (self.type, self.name, self.size))
 

--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -40,11 +40,9 @@ __author__ = "mferguson@willowgarage.com (Michael Ferguson)"
 import roslib
 import roslib.srvs
 import roslib.message
-import rospkg
-import rospy
 import traceback
 
-import os, sys, subprocess, re
+import os, sys, re
 
 # for copying files
 import shutil
@@ -217,7 +215,6 @@ class ArrayDataType(PrimitiveDataType):
             f.write('      %s()%s\n' % (self.name, trailer))
 
     def make_declaration(self, f):
-        c = self.cls("*"+self.name, self.type, self.bytes)
         if self.size == None:
             f.write('      uint32_t %s_length;\n' % self.name)
             f.write('      typedef %s _%s_type;\n' % (self.type, self.name))
@@ -512,7 +509,6 @@ def MakeLibrary(package, output_path, rospack):
                 messages.append( Message(f[0:-4], package, definition, md5sum) )
 
     # find the services in this package
-    services = list()
     if (os.path.exists(pkg_dir+"/srv/")):
         if messages == list():
             print('Exporting %s\n'%package)


### PR DESCRIPTION
Updating message generation to provide a typedef for each message variable.
This allows for rosserial client applications to define a size/type variable to match that of a message.

This is already present in roscpp message headers.

An example of the newly generated typedefs in the message header:
```c++
  class Status : public ros::Msg
  {
    public:
      typedef std_msgs::Header _header_type;
      _header_type header;
      typedef const char* _hardware_id_type;
      _hardware_id_type hardware_id;
      typedef ros::Duration _mcu_uptime_type;
      _mcu_uptime_type mcu_uptime;
      typedef ros::Duration _connection_uptime_type;
      _connection_uptime_type connection_uptime;
      typedef float _pcb_temperature_type;
      _pcb_temperature_type pcb_temperature;
      typedef float _mcu_temperature_type;
      _mcu_temperature_type mcu_temperature;
      typedef float _battery_temperature_type;
      _battery_temperature_type battery_temperature;
      typedef uint16_t _stop_type;
      _stop_type stop;
      typedef float _measured_battery_type;
      _measured_battery_type measured_battery;
      typedef float _measured_12v_type;
      _measured_12v_type measured_12v;
      typedef float _measured_5v_type;
      _measured_5v_type measured_5v;
      typedef float _drive_current_type;
      _drive_current_type drive_current;
      typedef float _user_current_type;
      _user_current_type user_current;
      typedef float _computer_current_type;
      _computer_current_type computer_current;
      typedef float _total_current_type;
      _total_current_type total_current;
      uint32_t foo_length;
      typedef float _foo_type;
      _foo_type st_foo;
      _foo_type * foo;
```