### PR TITLE
adding custom baudrate on initNode

### DIFF
--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -160,6 +160,26 @@ namespace ros {
         topic_ = 0;
       };
 
+      /* Start with a certain baudrate */
+      void initNode(long baudrate){
+        hardware_.setBaud(baudrate);
+        hardware_.init();
+        mode_ = 0;
+        bytes_ = 0;
+        index_ = 0;
+        topic_ = 0;
+      };
+
+      /* Start a named port and a certain baudrate*/
+      void initNode(char *portName, long baudrate){
+        hardware_.setBaud(baudrate);
+        hardware_.init(portName);
+        mode_ = 0;
+        bytes_ = 0;
+        index_ = 0;
+        topic_ = 0;
+      };
+
     protected:
       //State machine variables for spinOnce
       int mode_;


### PR DESCRIPTION
Hi,

This PR aims to add the ability to change the baudrate of the Serial Hardware on the initialisation of the nodeHandle.

Example to use the 115200 baudrate :

```
  nh.initNode(115200);
```

Tested and working on an Arduino, with `serial_node.py` on a baudrate of 115200 instead of 57600.