### PR TITLE
Fix typo in embedded linux when using library

### DIFF
--- a/rosserial_embeddedlinux/src/ros_lib/embedded_linux_hardware.h
+++ b/rosserial_embeddedlinux/src/ros_lib/embedded_linux_hardware.h
@@ -38,9 +38,9 @@
 #include <iostream>
 
 #ifdef BUILD_LIBROSSERIALEMBEDDEDLINUX
-extern "C" int elCommInit(char *portName, int baud);
+extern "C" int elCommInit(const char *portName, int baud);
 extern "C" int elCommRead(int fd);
-extern "C" elCommWrite(int fd, uint8_t* data, int length);
+extern "C" int elCommWrite(int fd, uint8_t* data, int length);
 #endif
 
 #define DEFAULT_PORT "/dev/ttyAM1"


### PR DESCRIPTION
When trying to compile an embedded linux program using something similar to the makefile found [here](http://wiki.ros.org/rosserial_embeddedlinux/Tutorials/Advanced%20Techniques), I ran into some build errors on these lines. It seems the function signatures are different here then when used without libraries through embedded_linux_hardware.h

I also noticed that when messages with string enums are built, they don't put the quotes around the value, so they will not compile when imported. This is fixed with the second commit.