### PR TITLE
Fixed bug reported in Issue 272

### DIFF
--- a/rosserial_arduino/arduino-cmake/cmake/Platform/Arduino.cmake
+++ b/rosserial_arduino/arduino-cmake/cmake/Platform/Arduino.cmake
@@ -283,6 +283,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #=============================================================================#
 cmake_minimum_required(VERSION 2.8.5)
+cmake_policy(SET CMP0054 NEW)
 include(CMakeParseArguments)
 
 


### PR DESCRIPTION
CMake will crash when interpreting source code in line 919, if the bracket "( )" span multiple lines.
This is because each line is scanned individually and the old CMP0054 is used. This causes CMAKE to try and interpret the line, find missmatching brackets and crash.

The fix changes to the new CMP0054, which resolves this problem.
This pull request has been submitted as a fix for #272 