### PR TITLE
Add support for STM32F1 with stm32duino.

### DIFF
--- a/rosserial_arduino/src/ros_lib/ArduinoHardware.h
+++ b/rosserial_arduino/src/ros_lib/ArduinoHardware.h
@@ -54,6 +54,9 @@
 #elif defined(USE_USBCON)
   // Arduino Leonardo USB Serial Port
   #define SERIAL_CLASS Serial_
+#elif defined(__STM32F1__) and !(defined(USE_STM32_HW_SERIAL))
+  // Stm32duino Maple mini USB Serial Port
+  #define SERIAL_CLASS USBSerial
 #else 
   #include <HardwareSerial.h>  // Arduino AVR
   #define SERIAL_CLASS HardwareSerial
@@ -70,7 +73,7 @@ class ArduinoHardware {
 #if defined(USBCON) and !(defined(USE_USBCON))
       /* Leonardo support */
       iostream = &Serial1;
-#elif defined(USE_TEENSY_HW_SERIAL)
+#elif defined(USE_TEENSY_HW_SERIAL) or defined(USE_STM32_HW_SERIAL)
       iostream = &Serial1;
 #else
       iostream = &Serial;


### PR DESCRIPTION
The cheap dev boards based on STM32 are becoming quite popular.

The Stm32duino community provides Arduino support for these boards ([wiki.stm32duino.com](http://wiki.stm32duino.com/index.php?title=Main_Page)).

So I have added a support for both USB and Hardware serial ports (with flag `USE_STM32_HW_SERIAL` like the one for Teensy).

Tested on Maple Mini and "Blue Pill" (cheap STM32F103C8T6 dev board) with
both USB Serial Port and Hardware Serial Port 1.