### PR TITLE
Add class member method callback support for Service Server.

### DIFF
--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -361,8 +361,8 @@ namespace ros {
       }
 
       /* Register a new Service Server */
-      template<typename MReq, typename MRes>
-      bool advertiseService(ServiceServer<MReq,MRes>& srv){
+      template<typename MReq, typename MRes, typename ObjT>
+      bool advertiseService(ServiceServer<MReq,MRes,ObjT>& srv){
         bool v = advertise(srv.pub);
         for(int i = 0; i < MAX_SUBSCRIBERS; i++){
           if(subscribers[i] == 0){ // empty slot

--- a/rosserial_client/src/ros_lib/ros/service_server.h
+++ b/rosserial_client/src/ros_lib/ros/service_server.h
@@ -42,8 +42,39 @@
 
 namespace ros {
 
-  template<typename MReq , typename MRes>
+  template<typename MReq , typename MRes, typename ObjT=void>
   class ServiceServer : public Subscriber_ {
+    public:
+      typedef void(ObjT::*CallbackT)(const MReq&,  MRes&);
+
+      ServiceServer(const char* topic_name, CallbackT cb, ObjT* obj) :
+        pub(topic_name, &resp, rosserial_msgs::TopicInfo::ID_SERVICE_SERVER + rosserial_msgs::TopicInfo::ID_PUBLISHER),
+        obj_(obj)
+      {
+        this->topic_ = topic_name;
+        this->cb_ = cb;
+      }
+
+      // these refer to the subscriber
+      virtual void callback(unsigned char *data){
+        req.deserialize(data);
+        (obj_->*cb_)(req,resp);
+        pub.publish(&resp);
+      }
+      virtual const char * getMsgType(){ return this->req.getType(); }
+      virtual const char * getMsgMD5(){ return this->req.getMD5(); }
+      virtual int getEndpointType(){ return rosserial_msgs::TopicInfo::ID_SERVICE_SERVER + rosserial_msgs::TopicInfo::ID_SUBSCRIBER; }
+
+      MReq req;
+      MRes resp;
+      Publisher pub;
+    private:
+      CallbackT cb_;
+      ObjT* obj_;
+  };
+
+  template<typename MReq , typename MRes>
+  class ServiceServer<MReq, MRes, void> : public Subscriber_ {
     public:
       typedef void(*CallbackT)(const MReq&,  MRes&);
 


### PR DESCRIPTION
Based on the work done for the Subscriber (#241).

I did not manage to add test because there are conflicts with the full Ros version.

Here is a simple test for Arduino:

```C++
#include <ros.h>
#include <std_srvs/SetBool.h>

ros::NodeHandle  nh;
using std_srvs::SetBool;

class MyClass
{
  public:
    static void callback_class_static(const SetBool::Request& req, SetBool::Response& res)
    {
      res.success = true;
      if (req.data == true)
        res.message = "Class static method: true";
      else
        res.message = "Class static method: false";
    }

    void callback_class(const SetBool::Request& req, SetBool::Response& res)
    {
      res.success = true;
      if (req.data == true)
        res.message = "Class method: true";
      else
        res.message = "Class method: false";
    }
};

MyClass mc;

void callback_non_class(const SetBool::Request& req, SetBool::Response& res)
{
  res.success = true;
  if (req.data == true)
    res.message = "Non-class: true";
  else
    res.message = "Non-class: false";
}

ros::ServiceServer<SetBool::Request, SetBool::Response> server_non_class("non_class_srv", &callback_non_class);
ros::ServiceServer<SetBool::Request, SetBool::Response> server_class_static("class_static_srv", &MyClass::callback_class_static);
ros::ServiceServer<SetBool::Request, SetBool::Response, MyClass> server_class("class_srv", &MyClass::callback_class, &mc);

void setup()
{
  nh.initNode();
  nh.advertiseService(server_non_class);
  nh.advertiseService(server_class_static);
  nh.advertiseService(server_class);
}

void loop()
{
  nh.spinOnce();
  delay(10);
}
```