### PR TITLE
Use ESP8266 header only if defined.

### DIFF
--- a/rosserial_arduino/src/ros_lib/ros.h
+++ b/rosserial_arduino/src/ros_lib/ros.h
@@ -37,7 +37,9 @@
 
 #include "ros/node_handle.h"
 #include "ArduinoHardware.h"
-#include "Esp8266Hardware.h"
+#if defined(ESP8266)
+  #include "Esp8266Hardware.h"
+#endif
 
 namespace ros
 {


### PR DESCRIPTION
#279 added support for ESP8266 but if the toolchain is not installed, the header file won't be find.