### PR TITLE
Fix POLICY CMP0054 unknown

### DIFF
--- a/rosserial_arduino/arduino-cmake/cmake/Platform/Arduino.cmake
+++ b/rosserial_arduino/arduino-cmake/cmake/Platform/Arduino.cmake
@@ -283,7 +283,9 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #=============================================================================#
 cmake_minimum_required(VERSION 2.8.5)
-cmake_policy(SET CMP0054 NEW)
+if(POLICY CMP0054)
+	cmake_policy(SET CMP0054 NEW)
+endif(POLICY CMP0054)
 include(CMakeParseArguments)
 
 


### PR DESCRIPTION
Hi, CMP0054 is only available since CMake 3.1.
I added a trivial condition to fix builds with rosserial_arduino on Ubuntu 14.04 (CMake 2.8.122).
