### PR TITLE
Address issues connecting Arduino DUE (see issue #284)

### DIFF
--- a/rosserial_arduino/src/ros_lib/ArduinoHardware.h
+++ b/rosserial_arduino/src/ros_lib/ArduinoHardware.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Willow Garage, Inc.
@@ -54,10 +54,10 @@
 #elif defined(USE_USBCON)
   // Arduino Leonardo USB Serial Port
   #define SERIAL_CLASS Serial_
-#elif (defined(__STM32F1__) and !(defined(USE_STM32_HW_SERIAL))) or defined(SPARK) 
+#elif (defined(__STM32F1__) and !(defined(USE_STM32_HW_SERIAL))) or defined(SPARK)
   // Stm32duino Maple mini USB Serial Port
   #define SERIAL_CLASS USBSerial
-#else 
+#else
   #include <HardwareSerial.h>  // Arduino AVR
   #define SERIAL_CLASS HardwareSerial
 #endif
@@ -70,8 +70,8 @@ class ArduinoHardware {
     }
     ArduinoHardware()
     {
-#if defined(USBCON) and !(defined(USE_USBCON))
-      /* Leonardo support */
+#if defined(USBCON) and !(defined(USE_USBCON)) and !(defined(_SAM3XA_))
+      /* Leonardo support but ignore if DUE*/
       iostream = &Serial1;
 #elif defined(USE_TEENSY_HW_SERIAL) or defined(USE_STM32_HW_SERIAL)
       iostream = &Serial1;
@@ -84,17 +84,17 @@ class ArduinoHardware {
       this->iostream = h.iostream;
       this->baud_ = h.baud_;
     }
-  
+
     void setBaud(long baud){
       this->baud_= baud;
     }
-  
+
     int getBaud(){return baud_;}
 
     void init(){
 #if defined(USE_USBCON)
       // Startup delay as a fail-safe to upload a new sketch
-      delay(3000); 
+      delay(3000);
 #endif
       iostream->begin(baud_);
     }


### PR DESCRIPTION
Adds code to ignore the Leonardo support if the DUE processor is
detected resulting in iostream = &Serial, instead of &Serial1 (line 73
in ArduionHardware.h).