### PR TITLE
Use the ! prefix introduced in gcc4mbed for mbed examples

### DIFF
--- a/rosserial_mbed/src/examples/ADC/makefile
+++ b/rosserial_mbed/src/examples/ADC/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_mbed_ADC
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 

--- a/rosserial_mbed/src/examples/Blink/makefile
+++ b/rosserial_mbed/src/examples/Blink/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_mbed_Blink
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 

--- a/rosserial_mbed/src/examples/Clapper/makefile
+++ b/rosserial_mbed/src/examples/Clapper/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_mbed_Clapper
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 

--- a/rosserial_mbed/src/examples/GroveBuzzer/makefile
+++ b/rosserial_mbed/src/examples/GroveBuzzer/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_grove_buzzer
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 

--- a/rosserial_mbed/src/examples/GroveCollision/makefile
+++ b/rosserial_mbed/src/examples/GroveCollision/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_grove_collision
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 

--- a/rosserial_mbed/src/examples/GrovePIRMotionSensor/makefile
+++ b/rosserial_mbed/src/examples/GrovePIRMotionSensor/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_pir_motion_sensor
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 

--- a/rosserial_mbed/src/examples/GroveTemperatureHumidity/makefile
+++ b/rosserial_mbed/src/examples/GroveTemperatureHumidity/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_grove_temperature_humidity
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 

--- a/rosserial_mbed/src/examples/HelloWorld/makefile
+++ b/rosserial_mbed/src/examples/HelloWorld/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_mbed_HelloWorld
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 

--- a/rosserial_mbed/src/examples/IrRanger/makefile
+++ b/rosserial_mbed/src/examples/IrRanger/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_mbed_IrRanger
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 

--- a/rosserial_mbed/src/examples/Logging/makefile
+++ b/rosserial_mbed/src/examples/Logging/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_mbed_Logging
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 

--- a/rosserial_mbed/src/examples/MotorShield/makefile
+++ b/rosserial_mbed/src/examples/MotorShield/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_motor_shield
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 

--- a/rosserial_mbed/src/examples/Odom/makefile
+++ b/rosserial_mbed/src/examples/Odom/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_mbed_Odom
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 

--- a/rosserial_mbed/src/examples/ServiceClient/makefile
+++ b/rosserial_mbed/src/examples/ServiceClient/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_mbed_ServiceClient
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 

--- a/rosserial_mbed/src/examples/ServiceServer/makefile
+++ b/rosserial_mbed/src/examples/ServiceServer/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_mbed_ServiceServer
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 

--- a/rosserial_mbed/src/examples/ServoControl/makefile
+++ b/rosserial_mbed/src/examples/ServoControl/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_mbed_ServoControl
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 

--- a/rosserial_mbed/src/examples/Temperature/makefile
+++ b/rosserial_mbed/src/examples/Temperature/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_mbed_Temperature
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 

--- a/rosserial_mbed/src/examples/TimeTF/makefile
+++ b/rosserial_mbed/src/examples/TimeTF/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_mbed_TimeTF
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 

--- a/rosserial_mbed/src/examples/Ultrasound/makefile
+++ b/rosserial_mbed/src/examples/Ultrasound/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_mbed_Ultrasound
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 

--- a/rosserial_mbed/src/examples/button_example/makefile
+++ b/rosserial_mbed/src/examples/button_example/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_mbed_button_example
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 

--- a/rosserial_mbed/src/examples/pubsub/makefile
+++ b/rosserial_mbed/src/examples/pubsub/makefile
@@ -1,7 +1,7 @@
 PROJECT         := rosserial_mbed_pubsub
 DEVICES         := LPC1768 KL25Z NUCLEO_F401RE
 GCC4MBED_DIR    := $(GCC4MBED_DIR)
-USER_LIBS       := $(ROS_LIB_DIR)
+USER_LIBS       := !$(ROS_LIB_DIR) $(ROS_LIB_DIR)/BufferedSerial
 NO_FLOAT_SCANF  := 1
 NO_FLOAT_PRINTF := 1
 


### PR DESCRIPTION
Follows the changes introduced in the following commit:
https://github.com/adamgreen/gcc4mbed/commit/7d79ef307e65f4f913bed655c887a632352c286c

Refer to adamgreen/gcc4mbed#64 for more details.

Without these changes, I get the following linker error when compiling:

```
Linking NUCLEO_F401RE/rosserial_mbed_Blink.elf
KL25Z/Blink.o: In function `ros::NodeHandle_<MbedHardware, 25, 25, 512, 512, ros::DefaultReadOutBuffer_>::setNow(ros::Time&)':
/home/naoki/ros/ubuntu/lib/ros_lib/ros/node_handle.h:393: undefined reference to `normalizeSecNSec'
collect2: error: ld returned 1 exit status
make: *** [KL25Z/rosserial_mbed_Blink.elf] Error 1
make: *** Waiting for unfinished jobs....
LPC1768/Blink.o: In function `ros::NodeHandle_<MbedHardware, 25, 25, 512, 512, ros::DefaultReadOutBuffer_>::setNow(ros::Time&)':
/home/naoki/ros/ubuntu/lib/ros_lib/ros/node_handle.h:393: undefined reference to `normalizeSecNSec'
collect2: error: ld returned 1 exit status
make: *** [LPC1768/rosserial_mbed_Blink.elf] Error 1
NUCLEO_F401RE/Blink.o: In function `ros::NodeHandle_<MbedHardware, 25, 25, 512, 512, ros::DefaultReadOutBuffer_>::setNow(ros::Time&)':
/home/naoki/ros/ubuntu/lib/ros_lib/ros/node_handle.h:393: undefined reference to `normalizeSecNSec'
collect2: error: ld returned 1 exit status
make: *** [NUCLEO_F401RE/rosserial_mbed_Blink.elf] Error 1
```