### PR TITLE
Support for MKL82Z

### DIFF
--- a/rosserial_mkl82z/CMakeLists.txt
+++ b/rosserial_mkl82z/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(rosserial_mkl82z)
+
+find_package(catkin REQUIRED)
+
+catkin_package()
+
+include_directories()
+
+install(DIRECTORY src/ros_lib
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/src
+  )

--- a/rosserial_mkl82z/README.md
+++ b/rosserial_mkl82z/README.md
@@ -1,0 +1,8 @@
+## rosserial_mkl82z
+
+This is a rosserial client implementation for the MKL82Z boards from NXP.
+
+### Dependencies
+This package depends on the SDK supplied by NXP, available
+[here](https://mcuxpresso.nxp.com/en/builder). Is is tested with version
+2.2, built for Linux with GCC ARM Embedded toolchain.

--- a/rosserial_mkl82z/package.xml
+++ b/rosserial_mkl82z/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package>
+  <name>rosserial_mkl82z</name>
+  <version>0.0.0</version>
+  <description>Library for ROSserial usage on NXP MKL82Z</description>
+
+  <author>Sindre Hansen</author>
+  <maintainer email="sindrehansen92@gmail.com">Sindre Hansen</maintainer>
+
+  <license>BSD</license>
+
+  <url type="website">http://wiki.ros.org/rosserial_mkl82z</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+</package>

--- a/rosserial_mkl82z/src/ros_lib/mkl82z_hardware.h
+++ b/rosserial_mkl82z/src/ros_lib/mkl82z_hardware.h
@@ -1,3 +1,35 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *  * Neither the name of Willow Garage, Inc. nor the names of its
+ *    contributors may be used to endorse or promote prducts derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+*/
+
 #ifndef ROS_MKL82Z_HARDWARE_H
 #define ROS_MKL82Z_HARDWARE_H
 

--- a/rosserial_mkl82z/src/ros_lib/mkl82z_hardware.h
+++ b/rosserial_mkl82z/src/ros_lib/mkl82z_hardware.h
@@ -1,0 +1,23 @@
+#ifndef ROS_MKL82Z_HARDWARE_H
+#define ROS_MKL82Z_HARDWARE_H
+
+
+class Mkl82zHardware {
+  Mkl82zHardware();
+
+  void init(){
+  }
+
+  int read(){
+    return 0;
+  }
+
+  void write(uint8_t*, int length){
+  }
+
+  unsigned long time(){
+    return 0;
+  }
+};
+
+#endif /* ROS_MKL82Z_HARDWARE_H */

--- a/rosserial_mkl82z/src/ros_lib/mkl82z_hardware.h
+++ b/rosserial_mkl82z/src/ros_lib/mkl82z_hardware.h
@@ -1,23 +1,35 @@
 #ifndef ROS_MKL82Z_HARDWARE_H
 #define ROS_MKL82Z_HARDWARE_H
 
-
+#ifdef __cplusplus
+extern "C" {
+#include "mkl82z_uart.h"
+}
 class Mkl82zHardware {
-  Mkl82zHardware();
+public:
+  Mkl82zHardware(){}
 
   void init(){
+    MKL82Z_PIT_init();
+    MKL82Z_UART_init();
   }
 
   int read(){
-    return 0;
+    return MKL82Z_UART_recbyte();
   }
 
-  void write(uint8_t*, int length){
+  void write(uint8_t* data_buff, int length){
+    uint16_t ii;
+    for(ii=0;ii<length;ii++)
+    {
+      MKL82Z_UART_write_byte(data_buff[ii]);
+    }
   }
 
   unsigned long time(){
-    return 0;
+    return MKL82Z_time();
   }
 };
 
+#endif /* __cplusplus */
 #endif /* ROS_MKL82Z_HARDWARE_H */

--- a/rosserial_mkl82z/src/ros_lib/mkl82z_uart.c
+++ b/rosserial_mkl82z/src/ros_lib/mkl82z_uart.c
@@ -1,0 +1,117 @@
+#include "mkl82z_uart.h"
+
+uint8_t  UART_RX_BUFF[UART_RX_BUFF_LEN];
+uint8_t  UART_TX_BUFF[UART_TX_BUFF_LEN];
+
+volatile uint32_t overflow_ms = 0;
+volatile uint16_t Rx_UART_HEAD = 0;
+volatile uint16_t Rx_UART_TAIL = 0;
+volatile uint16_t Tx_UART_HEAD = 0;
+volatile uint16_t Tx_UART_TAIL = 0;
+
+
+void MKL82Z_LPUART_IRQHandler()
+{
+  uint8_t data;
+  uint16_t ii;
+  if((kLPUART_RxDataRegFullFlag)&LPUART_GetStatusFlags(MKL82Z_LPUART))
+  {
+    data = MKL82Z_LPUART->DATA;
+
+    ii = (uint16_t) (Rx_UART_HEAD+1)%UART_RX_BUFF_LEN;
+    if(ii != Rx_UART_TAIL )
+    {
+      UART_RX_BUFF[Rx_UART_HEAD] = data;
+      Rx_UART_HEAD = ii;
+    }
+  }
+  else if(kLPUART_TxDataRegEmptyFlag & LPUART_GetStatusFlags(MKL82Z_LPUART))
+  {
+    data = UART_TX_BUFF[Tx_UART_TAIL];
+    Tx_UART_TAIL = (Tx_UART_TAIL+1) % UART_TX_BUFF_LEN;
+    LPUART_WriteByte(MKL82Z_LPUART,data);
+    if(Tx_UART_TAIL == Tx_UART_HEAD )
+    {
+      LPUART_DisableInterrupts(MKL82Z_LPUART,kLPUART_TxDataRegEmptyInterruptEnable);
+    }
+  }
+}
+
+void MKL82Z_PIT0_IRQHandler()
+{
+  PIT_ClearStatusFlags(PIT, kPIT_Chnl_0, kPIT_TimerFlag);
+  overflow_ms++;
+}
+
+void MKL82Z_PIT_init()
+{
+  pit_config_t pitConfig;
+  PIT_GetDefaultConfig(&pitConfig);
+  PIT_Init(PIT, &pitConfig);
+  PIT_SetTimerPeriod(PIT,kPIT_Chnl_0,USEC_TO_COUNT(1000U, MKL82Z_PIT_SRC_CLK));
+  PIT_EnableInterrupts(PIT, kPIT_Chnl_0, kPIT_TimerInterruptEnable);
+  EnableIRQ(MKL82Z_IRQ_ID);
+  PIT_StartTimer(PIT, kPIT_Chnl_0);
+}
+
+void MKL82Z_UART_init()
+{
+  int ii;
+  lpuart_config_t config;
+  CLOCK_SetLpuartClock(1U);
+  LPUART_GetDefaultConfig(&config);
+  config.baudRate_Bps = 57600;
+  config.enableTx = true;
+  config.enableRx = true;
+  for(ii=0;ii<30000;ii++)
+  {
+    __asm("NOP");
+  }
+  LPUART_Init(MKL82Z_LPUART, &config, CLOCK_GetFreq(MKL82Z_CLK_SEL));
+  LPUART_DisableInterrupts(MKL82Z_LPUART,kLPUART_TxDataRegEmptyInterruptEnable);
+  LPUART_EnableInterrupts(MKL82Z_LPUART,kLPUART_RxDataRegFullInterruptEnable);
+  EnableIRQ(MKL82Z_LPUART_IRQn);
+}
+
+int16_t MKL82Z_UART_recbyte()
+{
+  uint8_t data;
+  if(Rx_UART_HEAD == Rx_UART_TAIL)
+  {
+    return -1;
+  }
+  else
+  {
+    data = UART_RX_BUFF[Rx_UART_TAIL];
+    Rx_UART_TAIL = (uint16_t) (Rx_UART_TAIL+1) %UART_RX_BUFF_LEN;
+    return data;
+  }
+}
+
+int MKL82Z_UART_write_byte(uint8_t data)
+{
+  uint16_t ii;
+  if((Tx_UART_HEAD==Tx_UART_TAIL)&&(kLPUART_TxDataRegEmptyFlag & LPUART_GetStatusFlags(MKL82Z_LPUART)))
+  {
+    LPUART_WriteByte(MKL82Z_LPUART,data);
+    return 1;
+  }
+  ii = (Tx_UART_HEAD+1) % UART_TX_BUFF_LEN;
+  while (ii==Tx_UART_TAIL)
+  {
+    __asm("NOP");
+  }
+  UART_TX_BUFF[Tx_UART_HEAD] = data;
+  Tx_UART_HEAD = ii;
+  LPUART_EnableInterrupts(MKL82Z_LPUART,kLPUART_TxDataRegEmptyInterruptEnable);
+  return 1;
+}
+
+uint32_t MKL82Z_time()
+{
+  uint32_t now;
+  PIT_DisableInterrupts(PIT, kPIT_Chnl_0, kPIT_TimerInterruptEnable);
+  now = overflow_ms;
+  PIT_EnableInterrupts(PIT, kPIT_Chnl_0, kPIT_TimerInterruptEnable);
+  return now;
+}

--- a/rosserial_mkl82z/src/ros_lib/mkl82z_uart.h
+++ b/rosserial_mkl82z/src/ros_lib/mkl82z_uart.h
@@ -1,3 +1,35 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *  * Neither the name of Willow Garage, Inc. nor the names of its
+ *    contributors may be used to endorse or promote prducts derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+*/
+
 #ifndef MKL82Z_UART_H
 #define MKL82Z_UART_H
 

--- a/rosserial_mkl82z/src/ros_lib/mkl82z_uart.h
+++ b/rosserial_mkl82z/src/ros_lib/mkl82z_uart.h
@@ -1,0 +1,31 @@
+#ifndef MKL82Z_UART_H
+#define MKL82Z_UART_H
+
+#include "fsl_lpuart.h"
+#include "fsl_pit.h"
+
+
+#define MKL82Z_LPUART LPUART0
+#define MKL82Z_LPUART_IRQn LPUART0_IRQn
+#define MKL82Z_LPUART_IRQHandler LPUART0_IRQHandler
+#define MKL82Z_PIT0_IRQHandler PIT0_IRQHandler
+#define MKL82Z_CLK_SEL kCLOCK_PllFllSelClk
+#define MKL82Z_PIT_SRC_CLK CLOCK_GetFreq(kCLOCK_BusClk)
+#define MKL82Z_IRQ_ID PIT0_IRQn
+#define UART_RX_BUFF_LEN 256
+#define UART_TX_BUFF_LEN 256
+
+extern volatile uint16_t Rx_UART_HEAD;
+extern volatile uint16_t Rx_UART_TAIL;
+extern volatile uint16_t Tx_UART_HEAD;
+extern volatile uint16_t Tx_UART_TAIL;
+
+void MKL82Z_PIT0_IRQHandler();
+void MKL82Z_LPUART_IRQHandler();
+void MKL82Z_UART_init();
+void MKL82Z_PIT_init();
+int16_t MKL82Z_UART_recbyte();
+int MKL82Z_UART_write_byte(uint8_t data);
+uint32_t MKL82Z_time();
+
+#endif /* MKL82Z_UART_H */

--- a/rosserial_mkl82z/src/ros_lib/ros.h
+++ b/rosserial_mkl82z/src/ros_lib/ros.h
@@ -1,0 +1,12 @@
+#ifndef _ROS_H_
+#define _ROS_H_
+
+#include "ros/node_handle.h"
+#include "mkl82z_hardware.h"
+
+namespace ros
+{
+  typedef NodeHandle_<Mkl82zHardware> NodeHandle;
+}
+
+#endif

--- a/rosserial_mkl82z/src/ros_lib/ros.h
+++ b/rosserial_mkl82z/src/ros_lib/ros.h
@@ -1,3 +1,35 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *  * Neither the name of Willow Garage, Inc. nor the names of its
+ *    contributors may be used to endorse or promote prducts derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+*/
+
 #ifndef _ROS_H_
 #define _ROS_H_
 

--- a/rosserial_mkl82z/src/scripts/make_libraries.py
+++ b/rosserial_mkl82z/src/scripts/make_libraries.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+#####################################################################
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+THIS_PACKAGE = "rosserial_mkl82z"
+
+__usage__ = """
+make_libraries.py generates the MKL82Z rosserial library files.
+
+rosrun rosserial_mkl82z make_libraries.py <output_path>
+"""
+
+import rospkg
+import rosserial_client
+from rosserial_client.make_library import *
+
+# for copying files
+import shutil
+
+ROS_TO_EMBEDDED_TYPES = {
+    'bool'    :   ('bool',              1, PrimitiveDataType, []),
+    'byte'    :   ('int8_t',            1, PrimitiveDataType, []),
+    'int8'    :   ('int8_t',            1, PrimitiveDataType, []),
+    'char'    :   ('uint8_t',           1, PrimitiveDataType, []),
+    'uint8'   :   ('uint8_t',           1, PrimitiveDataType, []),
+    'int16'   :   ('int16_t',           2, PrimitiveDataType, []),
+    'uint16'  :   ('uint16_t',          2, PrimitiveDataType, []),
+    'int32'   :   ('int32_t',           4, PrimitiveDataType, []),
+    'uint32'  :   ('uint32_t',          4, PrimitiveDataType, []),
+    'int64'   :   ('int64_t',           8, PrimitiveDataType, []),
+    'uint64'  :   ('uint64_t',          4, PrimitiveDataType, []),
+    'float32' :   ('float',             4, PrimitiveDataType, []),
+    'float64' :   ('double',            8, PrimitiveDataType, []),
+    'time'    :   ('ros::Time',         8, TimeDataType, ['ros/time']),
+    'duration':   ('ros::Duration',     8, TimeDataType, ['ros/duration']),
+    'string'  :   ('char*',             0, StringDataType, []),
+    'Header'  :   ('std_msgs::Header',  0, MessageDataType, ['std_msgs/Header'])
+}
+
+# need correct inputs
+if (len(sys.argv) < 2):
+    print __usage__
+    exit()
+
+# get output path
+path = sys.argv[1]
+if path[-1] == "/":
+    path = path[0:-1]
+print "\nExporting to %s" % path
+
+rospack = rospkg.RosPack()
+
+# copy ros_lib stuff in
+rosserial_mkl82z_dir = rospack.get_path(THIS_PACKAGE)
+shutil.copytree(rosserial_mkl82z_dir+"/src/ros_lib", path+"/ros_lib")
+rosserial_client_copy_files(rospack, path+"/ros_lib/")
+
+# generate messages
+rosserial_generate(rospack, path+"/ros_lib", ROS_TO_EMBEDDED_TYPES)


### PR DESCRIPTION
This PR adds rosserial support for the MKL82Z chips from NXP. 
The UART driver depends on the SDK from NXP, I have added a note about that in the readme. 
Please review and let me know if there are any issues I need to fix, or anything else that needs to be done before merging.

Closes #300 