### PR TITLE
Add requestTopics to correct publish before configured

### DIFF
--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -493,6 +493,7 @@ class SerialClient:
                         self.callbacks[topic_id](msg)
                     except KeyError:
                         rospy.logerr("Tried to publish before configured, topic id %d" % topic_id)
+                        self.requestTopics()
                     rospy.sleep(0.001)
                 else:
                     rospy.loginfo("wrong checksum for topic id and msg")


### PR DESCRIPTION
Right now, `serial_node.py` can not recover from `Tried to publish before configured` if the topic somehow was not configured properly.

This add a `requestTopics()` in order to recover from the above state. 