### PR TITLE
Backporting #248 to indigo-devel

### DIFF
--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -403,13 +403,21 @@ class SerialClient:
 
     def tryRead(self, length):
         try:
+            read_start = time.time()
+            read_current = read_start
             bytes_remaining = length
             result = bytearray()
-            while bytes_remaining != 0:
+            while bytes_remaining != 0 and read_current - read_start < self.timeout:
                 received = self.port.read(bytes_remaining)
                 if len(received) != 0:
                     result.extend(received)
                     bytes_remaining -= len(received)
+                read_current = time.time()
+
+            if bytes_remaining != 0:
+                rospy.logwarn("Serial Port read returned short (expected %d bytes, received %d instead)."
+                              % (length, len(length - bytes_remaining)))
+                raise IOError()
 
             return bytes(result)
         except Exception as e:

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -403,12 +403,15 @@ class SerialClient:
 
     def tryRead(self, length):
         try:
-            bytes_read = self.port.read(length)
-            if len(bytes_read) < length:
-                rospy.logwarn("Serial Port read returned short (expected %d bytes, received %d instead)."
-                              % (length, len(bytes_read)))
-                raise IOError()
-            return bytes_read
+            bytes_remaining = length
+            result = bytearray()
+            while bytes_remaining != 0:
+                received = self.port.read(bytes_remaining)
+                if len(received) != 0:
+                    result.extend(received)
+                    bytes_remaining -= len(received)
+
+            return bytes(result)
         except Exception as e:
             rospy.logwarn("Serial Port read failure: %s", e)
             raise IOError()


### PR DESCRIPTION
To suppress warn message `Serial Port read returned short (expected 99 bytes, received 64 instead).`
In #247 , this problem is reported only in ROS kinetic, but this also occurs in indigo.