### PR TITLE
In rosserial_arduino, changed embedded type size for ROS uint64 to 8 bytes from 4.

### DIFF
--- a/rosserial_arduino/src/rosserial_arduino/make_libraries.py
+++ b/rosserial_arduino/src/rosserial_arduino/make_libraries.py
@@ -60,7 +60,7 @@ ROS_TO_EMBEDDED_TYPES = {
     'int32'   :   ('int32_t',           4, PrimitiveDataType, []),
     'uint32'  :   ('uint32_t',          4, PrimitiveDataType, []),
     'int64'   :   ('int64_t',           8, PrimitiveDataType, []),
-    'uint64'  :   ('uint64_t',          4, PrimitiveDataType, []),
+    'uint64'  :   ('uint64_t',          8, PrimitiveDataType, []),
     'float32' :   ('float',             4, PrimitiveDataType, []),
     'float64' :   ('float',             4, AVR_Float64DataType, []),
     'time'    :   ('ros::Time',         8, TimeDataType, ['ros/time']),


### PR DESCRIPTION
As the title says. This fixed one error I was having, and it didn't seem to make sense to try to store a 64 bit datatype in 32 bits, as the generated serialization code was doing for my messages with fields of type uint64. I'm still getting oriented to rosserial, though, and it is possible I misunderstood something.