### PR TITLE
pyserial bug workaround to fix rosserial_test test against SerialClient.py

### DIFF
--- a/rosserial_python/nodes/serial_node.py
+++ b/rosserial_python/nodes/serial_node.py
@@ -51,6 +51,10 @@ if __name__=="__main__":
     port_name = rospy.get_param('~port','/dev/ttyUSB0')
     baud = int(rospy.get_param('~baud','57600'))
 
+    # for systems where pyserial yields errors in the fcntl.ioctl(self.fd, TIOCMBIS, \
+    # TIOCM_DTR_str) line, which causes an IOError, when using simulated port
+    fix_pyserial_for_test = rospy.get_param('~fix_pyserial_for_test', False)
+
     # TODO: should these really be global?
     tcp_portnum = int(rospy.get_param('/rosserial_embeddedlinux/tcp_port', '11411'))
     fork_server = rospy.get_param('/rosserial_embeddedlinux/fork_server', False)
@@ -81,7 +85,7 @@ if __name__=="__main__":
         while not rospy.is_shutdown():
             rospy.loginfo("Connecting to %s at %d baud" % (port_name,baud) )
             try:
-                client = SerialClient(port_name, baud)
+                client = SerialClient(port_name, baud, fix_pyserial_for_test=fix_pyserial_for_test)
                 client.run()
             except KeyboardInterrupt:
                 break

--- a/rosserial_test/include/rosserial_test/fixture.h
+++ b/rosserial_test/include/rosserial_test/fixture.h
@@ -76,7 +76,8 @@ class SingleClientFixture : public ::testing::Test {
 protected:
   static void SetModeFromParam() {
     std::string mode;
-    ros::param::get("~mode", mode);
+    // TODO should default be socket for testing purposes?
+    ros::param::param<std::string>("~mode", mode, "socket");
     ROS_INFO_STREAM("Using test mode [" << mode << "]");
     if (mode == "socket") {
       setup = new SocketSetup();

--- a/rosserial_test/include/rosserial_test/fixture.h
+++ b/rosserial_test/include/rosserial_test/fixture.h
@@ -76,8 +76,7 @@ class SingleClientFixture : public ::testing::Test {
 protected:
   static void SetModeFromParam() {
     std::string mode;
-    // TODO should default be socket for testing purposes?
-    ros::param::param<std::string>("~mode", mode, "socket");
+    ros::param::get("~mode", mode);
     ROS_INFO_STREAM("Using test mode [" << mode << "]");
     if (mode == "socket") {
       setup = new SocketSetup();

--- a/rosserial_test/test/rosserial_python_serial.test
+++ b/rosserial_test/test/rosserial_python_serial.test
@@ -1,5 +1,7 @@
 <launch>
-  <node pkg="rosserial_python" type="serial_node.py" name="rosserial_python_node" args="/tmp/rosserial_pty2" output="screen" />
+  <node pkg="rosserial_python" type="serial_node.py" name="rosserial_python_node" args="/tmp/rosserial_pty2" output="screen">
+    <param name="fix_pyserial_for_test" value="True" />
+  </node>
 
   <test test-name="rosserial_python_serial_test_publish_subscribe" pkg="rosserial_test"
         type="rosserial_test_publish_subscribe" time-limit="10.0">


### PR DESCRIPTION
With Ubuntu 16.04, ROS Kinetic, and (at least) either pyserial 3.0.1 or 3.4,  running `rostest rosserial_test rosserial_python_serial.test` fails with:
```
...
File "/usr/lib/python2.7/dist-packages/serial/serialposix.py", line 605, in _update_dtr_state
    fcntl.ioctl(self.fd, TIOCMBIS, TIOCM_DTR_str)
IOError: [Errno 22] Invalid argument
```
This adds an optional argument to `rosserial_python`'s `SerialClient.py` to fix this as a special case.
