### PR TITLE
Fix clang build on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: generic
 
 env:
   - CI_ROS_DISTRO=indigo CC=gcc CXX=g++ PATH=/usr/sbin:/usr/bin:/sbin:/bin
-  - CI_ROS_DISTRO=indigo CC=clang CXX=clang++ PATH=/usr/local/clang-3.5.0/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  - CI_ROS_DISTRO=indigo CC=clang CXX=clang++ PATH=/usr/local/clang-3.9.0/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 before_install:
   - sudo sh -c 'echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'


### PR DESCRIPTION
Update the hard-coded compiler path. Should investigate whether Travis's `compiler` option might be usable here— issue in the past has been how their VMs have non-system pythons installed that aren't able to see apt-installed python packages.

cf. https://docs.travis-ci.com/user/languages/c/#Choosing-compilers-to-test-against