### PR TITLE
[Arduino] Fix Esp8266 example directory

### DIFF
--- a/rosserial_arduino/src/ros_lib/examples/Esp8266HelloWorld/Esp8266HelloWorld.ino
+++ b/rosserial_arduino/src/ros_lib/examples/Esp8266HelloWorld/Esp8266HelloWorld.ino
@@ -1,9 +1,9 @@
 /*
  * rosserial Publisher Example
  * Prints "hello world!"
- * This intend to connect to a Wifi Access Point 
+ * This intend to connect to a Wifi Access Point
  * and a rosserial socket server.
- * You can launch the rosserial socket server with 
+ * You can launch the rosserial socket server with
  * roslaunch rosserial_server socket.launch
  * The default port is 11411
  *


### PR DESCRIPTION
An Arduino sketch must be in a directory which has the same name as the file in order to show up in the Arduino IDE.