### PR TITLE
[Client] Fix a warning in comparison.

### DIFF
--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -424,14 +424,14 @@ namespace ros {
 	  return 0;
 
         /* serialize message */
-        uint16_t l = msg->serialize(message_out+7);
+        int l = msg->serialize(message_out+7);
 
         /* setup the header */
         message_out[0] = 0xff;
         message_out[1] = PROTOCOL_VER;
         message_out[2] = (uint8_t) ((uint16_t)l&255);
         message_out[3] = (uint8_t) ((uint16_t)l>>8);
-	message_out[4] = 255 - ((message_out[2] + message_out[3])%256);
+        message_out[4] = 255 - ((message_out[2] + message_out[3])%256);
         message_out[5] = (uint8_t) ((int16_t)id&255);
         message_out[6] = (uint8_t) ((int16_t)id>>8);
 


### PR DESCRIPTION
The warning appears in the for-loop line 440 but the method `serialize()` returns an `int`.