### PR TITLE
[Arduino] Add ArduinoTcpHardware to use Arduino Ethernet shield.

### DIFF
--- a/rosserial_arduino/src/ros_lib/ArduinoTcpHardware.h
+++ b/rosserial_arduino/src/ros_lib/ArduinoTcpHardware.h
@@ -44,51 +44,61 @@
 #endif
 
 class ArduinoHardware {
-  public:
-    ArduinoHardware()
-    {
-    }
+public:
+  ArduinoHardware()
+  {
+  }
 
-    void setConnection(IPAddress &server, int port = 11411) {
-      server_ = server;
-      serverPort_ = port;
-    }
+  void setConnection(IPAddress &server, int port = 11411)
+  {
+    server_ = server;
+    serverPort_ = port;
+  }
 
-    IPAddress getLocalIP() {
+  IPAddress getLocalIP()
+  {
 #if defined(ESP8266)
-      return tcp_.localIP();
+    return tcp_.localIP();
 #else
-      return Ethernet.localIP();
+    return Ethernet.localIP();
 #endif
-    }
+  }
 
-    void init(){
+  void init()
+  {
+    tcp_.connect(server_, serverPort_);
+  }
+
+  int read(){
+    if (tcp_.connected())
+    {
+        return tcp_.read();
+    }
+    else
+    {
       tcp_.connect(server_, serverPort_);
     }
+    return -1;
+  }
 
-    int read(){
-      if(tcp_.connected()){
-          return tcp_.read();
-      }else{
-        tcp_.connect(server_, serverPort_);
-      }
-      return -1;
-    }
+  void write(const uint8_t* data, int length)
+  {
+    tcp_.write(data, length);
+  }
 
-    void write(const uint8_t* data, int length){
-      tcp_.write(data, length);
-    }
+  unsigned long time()
+  {
+    return millis();
+  }
 
-    unsigned long time(){return millis();}
-
-  protected:
+protected:
 #if defined(ESP8266)
-    WiFiClient tcp_;
+  WiFiClient tcp_;
 #else
-    EthernetClient tcp_;
+  EthernetClient tcp_;
 #endif
-    IPAddress server_;
-    uint16_t serverPort_ = 11411;
+  IPAddress server_;
+  uint16_t serverPort_ = 11411;
 };
 
 #endif

--- a/rosserial_arduino/src/ros_lib/ArduinoTcpHardware.h
+++ b/rosserial_arduino/src/ros_lib/ArduinoTcpHardware.h
@@ -1,6 +1,8 @@
-/* 
+/*
  * Software License Agreement (BSD License)
  *
+ * Copyright (c) 2011, Willow Garage, Inc.
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,49 +32,63 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef ESP8266HARDWARE_H
-#define ESP8266HARDWARE_H
+#ifndef ROS_ARDUINO_TCP_HARDWARE_H_
+#define ROS_ARDUINO_TCP_HARDWARE_H_
 
-#include <ESP8266WiFi.h>
+#include <Arduino.h>
+#if defined(ESP8266)
+  #include <ESP8266WiFi.h>
+#else
+  #include <SPI.h>
+  #include <Ethernet.h>
+#endif
 
-class Esp8266Hardware {
+class ArduinoHardware {
   public:
-    Esp8266Hardware()
+    ArduinoHardware()
     {
     }
-    
-    void setConnection(IPAddress &server, int port) {
-      this->server = server;
-      this->serverPort = port;
+
+    void setConnection(IPAddress &server, int port = 11411) {
+      server_ = server;
+      serverPort_ = port;
     }
-    
+
     IPAddress getLocalIP() {
-      return tcp.localIP();
+#if defined(ESP8266)
+      return tcp_.localIP();
+#else
+      return Ethernet.localIP();
+#endif
     }
 
-    void init() { 
-      this->tcp.connect(this->server, this->serverPort);
+    void init(){
+      tcp_.connect(server_, serverPort_);
     }
 
-    int read() {
-      if (this->tcp.connected()) {
-        return tcp.read();
-      } else {
-        this->tcp.connect(this->server, this->serverPort);
+    int read(){
+      if(tcp_.connected()){
+          return tcp_.read();
+      }else{
+        tcp_.connect(server_, serverPort_);
       }
       return -1;
-    };
-    
-    void write(const uint8_t* data, size_t length) {
-      tcp.write(data, length);
     }
 
-    unsigned long time() {return millis();}
+    void write(const uint8_t* data, int length){
+      tcp_.write(data, length);
+    }
+
+    unsigned long time(){return millis();}
 
   protected:
-    WiFiClient tcp;
-    IPAddress server; 
-    uint16_t serverPort = 11411;
+#if defined(ESP8266)
+    WiFiClient tcp_;
+#else
+    EthernetClient tcp_;
+#endif
+    IPAddress server_;
+    uint16_t serverPort_ = 11411;
 };
 
-#endif  // ESP8266HARDWARE_H
+#endif

--- a/rosserial_arduino/src/ros_lib/examples/TcpBlink/TcpBlink.ino
+++ b/rosserial_arduino/src/ros_lib/examples/TcpBlink/TcpBlink.ino
@@ -1,0 +1,47 @@
+/*
+ * rosserial Subscriber Example using TCP on Arduino Shield (Wiznet W5100 based)
+ * Blinks an LED on callback
+ */
+#include <SPI.h>
+#include <Ethernet.h>
+
+#define ROSSERIAL_ARDUINO_TCP
+
+#include <ros.h>
+#include <std_msgs/Empty.h>
+
+ros::NodeHandle  nh;
+
+// Shield settings
+byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };
+IPAddress ip(192, 168, 0, 177);
+
+// Server settings
+IPAddress server(192, 168, 0, 11);
+uint16_t serverPort = 11411;
+
+const uint8_t ledPin = 6; // 13 already used for SPI connection with the shield
+
+void messageCb( const std_msgs::Empty&){
+  digitalWrite(ledPin, HIGH-digitalRead(ledPin));   // blink the led
+}
+
+ros::Subscriber<std_msgs::Empty> sub("toggle_led", &messageCb );
+
+void setup()
+{
+  Ethernet.begin(mac, ip);
+  // give the Ethernet shield a second to initialize:
+  delay(1000);
+  pinMode(ledPin, OUTPUT);
+  nh.getHardware()->setConnection(server, serverPort);
+  nh.initNode();
+  nh.subscribe(sub);
+}
+
+void loop()
+{
+  nh.spinOnce();
+  delay(1);
+}
+

--- a/rosserial_arduino/src/ros_lib/examples/TcpHelloWorld/TcpHelloWorld.ino
+++ b/rosserial_arduino/src/ros_lib/examples/TcpHelloWorld/TcpHelloWorld.ino
@@ -1,0 +1,84 @@
+/*
+ * rosserial Publisher Example
+ * Prints "hello world!"
+ * This intend to connect to an Arduino Ethernet Shield
+ * and a rosserial socket server.
+ * You can launch the rosserial socket server with
+ * roslaunch rosserial_server socket.launch
+ * The default port is 11411
+ *
+ */
+#include <SPI.h>
+#include <Ethernet.h>
+
+// To use the TCP version of rosserial_arduino
+#define ROSSERIAL_ARDUINO_TCP
+
+#include <ros.h>
+#include <std_msgs/String.h>
+
+// Set the shield settings
+byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };
+IPAddress ip(192, 168, 0, 177);
+
+// Set the rosserial socket server IP address
+IPAddress server(192,168,0,11);
+// Set the rosserial socket server port
+const uint16_t serverPort = 11411;
+
+ros::NodeHandle nh;
+// Make a chatter publisher
+std_msgs::String str_msg;
+ros::Publisher chatter("chatter", &str_msg);
+
+// Be polite and say hello
+char hello[13] = "hello world!";
+uint16_t period = 1000;
+uint32_t last_time = 0;
+
+void setup()
+{
+  // Use serial to monitor the process
+  Serial.begin(115200);
+
+  // Connect the Ethernet
+  Ethernet.begin(mac, ip);
+
+  // Let some time for the Ethernet Shield to be initialized
+  delay(1000);
+
+  Serial.println("");
+  Serial.println("Ethernet connected");
+  Serial.println("IP address: ");
+  Serial.println(Ethernet.localIP());
+
+  // Set the connection to rosserial socket server
+  nh.getHardware()->setConnection(server, serverPort);
+  nh.initNode();
+
+  // Another way to get IP
+  Serial.print("IP = ");
+  Serial.println(nh.getHardware()->getLocalIP());
+
+  // Start to be polite
+  nh.advertise(chatter);
+}
+
+void loop()
+{
+  if(millis() - last_time >= period)
+  {
+    last_time = millis();
+    if (nh.connected())
+    {
+      Serial.println("Connected");
+      // Say hello
+      str_msg.data = hello;
+      chatter.publish( &str_msg );
+    } else {
+      Serial.println("Not Connected");
+    }
+  }
+  nh.spinOnce();
+  delay(1);
+}

--- a/rosserial_arduino/src/ros_lib/ros.h
+++ b/rosserial_arduino/src/ros_lib/ros.h
@@ -36,14 +36,16 @@
 #define _ROS_H_
 
 #include "ros/node_handle.h"
-#include "ArduinoHardware.h"
-#if defined(ESP8266)
-  #include "Esp8266Hardware.h"
+
+#if defined(ESP8266) or defined(ROSSERIAL_ARDUINO_TCP)
+  #include "ArduinoTcpHardware.h"
+#else
+  #include "ArduinoHardware.h"
 #endif
 
 namespace ros
 {
-#if defined(__AVR_ATmega8__) || defined(__AVR_ATmega168__)
+#if defined(__AVR_ATmega8__) or defined(__AVR_ATmega168__)
   /* downsize our buffers */
   typedef NodeHandle_<ArduinoHardware, 6, 6, 150, 150> NodeHandle;
 
@@ -51,16 +53,13 @@ namespace ros
 
   typedef NodeHandle_<ArduinoHardware, 25, 25, 280, 280> NodeHandle;
 
-#elif defined(ESP8266)
-
-  typedef NodeHandle_<Esp8266Hardware> NodeHandle;
-  
 #elif defined(SPARK)
+
   typedef NodeHandle_<ArduinoHardware, 10, 10, 2048, 2048> NodeHandle;
 
 #else
 
-  typedef NodeHandle_<ArduinoHardware> NodeHandle;
+  typedef NodeHandle_<ArduinoHardware> NodeHandle; // default 25, 25, 512, 512
 
 #endif   
 }


### PR DESCRIPTION
I have modified the ESP8266 hardware class to be able to use the Arduino Ethernet Shield for an Arduino TCP connexion.

I have added the `#define ROSSERIAL_ARDUINO_TCP` to enable the TCP mode. Maybe another string is more suitable?

The class has the same name `ArduinoHardware` in order to simplify the `ros.h` file. Only the included header file change.

I have added two simple exemples.

Tested with Arduino Nano, UNO, MEGA, Leonardo, DUE and ESP8266 based Wemos D1 Mini.
Note that with the Atmega328, the RAM is limited after the include of the Ethernet and rosserial libraries.