### PR TITLE
Copy src/examples to install dir so make_libraries.py doesn't fail

### DIFF
--- a/rosserial_embeddedlinux/CMakeLists.txt
+++ b/rosserial_embeddedlinux/CMakeLists.txt
@@ -9,6 +9,7 @@ catkin_package(CATKIN_DEPENDS)
 
 install(
   DIRECTORY src/ros_lib
+            src/examples
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/src
 )
 


### PR DESCRIPTION
src/examples for rosserial_embeddedlinux currently don't get copied to the install dir when running catkin_make causing make_libraries.py fail. Full details in issue #335 

Fix is simply adding src/examples to the directories that get copied in rosserial_embeddedlinux/CMakeLists.txt