### PR TITLE
Change the protocol to avoid needing a timeout per message in node_handle.h

### DIFF
--- a/rosserial_client/src/ros_lib/ros/msg.h
+++ b/rosserial_client/src/ros_lib/ros/msg.h
@@ -171,6 +171,10 @@ public:
         ffs = 0;
     }
 
+    // Return immediately if no escaping is needed
+    if (overhead == 0)
+	    return length;
+
     // Shift message to the right
     for (int i = length-1 ; i >= 0 ; --i)
       outbuffer[i+overhead] = outbuffer[i];

--- a/rosserial_client/src/ros_lib/ros/msg.h
+++ b/rosserial_client/src/ros_lib/ros/msg.h
@@ -141,6 +141,61 @@ public:
       var |= (arr[i] << (8 * i));
   }
 
+
+  /*
+   * @brief Serializes the message, then encodes it to eliminate sequences of
+   * three ff's.
+   *
+   * This function does its best to avoid allocating memory on the stack, at
+   * the expense of longer execution time. It does so by performing three
+   * passes. First, it computes how many more bytes will be needed. Then it
+   * shifts the message in the buffer that many bytes to the right. Finally it
+   * writes the message one last time inserting the escaping bytes.
+   */
+  int serializeAndEncode(unsigned char *outbuffer) const
+  {
+    int length = serialize(outbuffer);
+    int overhead = 0;
+    int ffs = 0;
+
+    // Compute overhead
+    for (int i = 0 ; i < length ; ++i) {
+      if (ffs == 2 && (outbuffer[i] == 0xff || outbuffer[i] == 0x00)) {
+        ffs = 0;
+        overhead++;
+      }
+
+      if (outbuffer[i] == 0xff)
+        ffs++;
+      else
+        ffs = 0;
+    }
+
+    // Shift message to the right
+    for (int i = length-1 ; i >= 0 ; --i)
+      outbuffer[i+overhead] = outbuffer[i];
+
+    // Write escaped message
+    ffs = 0;
+    unsigned char *w = outbuffer,
+                  *r = outbuffer + overhead;
+    for (int i = 0 ; i < length ; ++i, ++r) {
+      if (ffs == 2 && (*r == 0xff || *r == 0x00)) {
+        ffs = 0;
+        *w++ = 0x00;
+      }
+
+      if (*r == 0xff)
+        ffs++;
+      else
+        ffs = 0;
+
+      *w++ = *r;
+    }
+
+    return length + overhead;
+  }
+
 };
 
 }  // namespace ros

--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -569,23 +569,29 @@ public:
     if (id >= 100 && !configured_)
       return 0;
 
-    /* serialize message */
-    int l = msg->serialize(message_out + 7);
+    /* serialize and encode message */
+    int l = msg->serializeAndEncode(message_out + 11);
 
     /* setup the header */
     message_out[0] = 0xff;
-    message_out[1] = PROTOCOL_VER;
-    message_out[2] = (uint8_t)((uint16_t)l & 255);
-    message_out[3] = (uint8_t)((uint16_t)l >> 8);
-    message_out[4] = 255 - ((message_out[2] + message_out[3]) % 256);
-    message_out[5] = (uint8_t)((int16_t)id & 255);
-    message_out[6] = (uint8_t)((int16_t)id >> 8);
+    message_out[1] = 0xff;
+    message_out[2] = 0xff;
+    message_out[3] = PROTOCOL_VER;
+    message_out[4] = (uint8_t) ((uint16_t)l&255);
+    message_out[5] = (uint8_t) ((uint16_t)l>>8);
+    message_out[6] = 255 - ((message_out[4] + message_out[5])%256);
+    message_out[7] = 0x00;
+    message_out[8] = (uint8_t) ((int16_t)id&255);
+    message_out[9] = (uint8_t) ((int16_t)id>>8);
+    message_out[10] = 0x00;
 
     /* calculate checksum */
     int chk = 0;
-    for (int i = 5; i < l + 7; i++)
+    for (int i = 8; i < l + 11; i++)
       chk += message_out[i];
-    l += 7;
+    l += 11;
+
+    message_out[l++] = 0x00;
     message_out[l++] = 255 - (chk % 256);
 
     if (l <= OUTPUT_SIZE)

--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -102,8 +102,6 @@ const uint8_t MODE_NULL_3         = 10;
 const uint8_t MODE_MSG_CHECKSUM   = 11;    // checksum for msg and topic id
 
 
-const uint8_t SERIAL_MSG_TIMEOUT  = 20;   // 20 milliseconds to recieve all of message data
-
 using rosserial_msgs::TopicInfo;
 
 /* Node Handle */
@@ -214,7 +212,6 @@ protected:
   /* used for syncing the time */
   uint32_t last_sync_time;
   uint32_t last_sync_receive_time;
-  uint32_t last_msg_timeout_time;
 
 public:
   /* This function goes in your loop() function, it handles
@@ -229,15 +226,6 @@ public:
     if ((c_time - last_sync_receive_time) > (SYNC_SECONDS * 2200))
     {
       configured_ = false;
-    }
-
-    /* reset if message has timed out */
-    if (mode_ != MODE_SYNC)
-    {
-      if (c_time > last_msg_timeout_time)
-      {
-        mode_ = MODE_SYNC;
-      }
     }
 
     /* while available buffer, read data */
@@ -266,7 +254,6 @@ public:
       {
         // MODE_SYNC + handles truncated messages
         ffs_ = 0;
-        last_msg_timeout_time = c_time + SERIAL_MSG_TIMEOUT;
         mode_ = MODE_PROTOCOL_VER;
       }
       else if (mode_ == MODE_MESSAGE)        /* message data being recieved */

--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -85,7 +85,8 @@ const uint8_t SYNC_SECONDS  = 5;
  */
 const uint8_t PROTOCOL_VER1       = 0xff; // through groovy
 const uint8_t PROTOCOL_VER2       = 0xfe; // in hydro
-const uint8_t PROTOCOL_VER        = PROTOCOL_VER2;
+const uint8_t PROTOCOL_VER3       = 0xfd; // in hydro
+const uint8_t PROTOCOL_VER        = PROTOCOL_VER3;
 
 const uint8_t MODE_SYNC           = 0;
 const uint8_t MODE_PROTOCOL_VER   = 1;

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -361,7 +361,8 @@ class SerialClient:
         # The protocol version is sent as the 2nd sync byte emitted by each end
         self.protocol_ver1 = '\xff'
         self.protocol_ver2 = '\xfe'
-        self.protocol_ver = self.protocol_ver2
+        self.protocol_ver3 = '\xfd'
+        self.protocol_ver = self.protocol_ver3
 
         self.publishers = dict()  # id:Publishers
         self.subscribers = dict() # topic:Subscriber
@@ -463,7 +464,7 @@ class SerialClient:
                 if ( flag[1] != self.protocol_ver):
                     self.sendDiagnostics(diagnostic_msgs.msg.DiagnosticStatus.ERROR, "Mismatched protocol version in packet: lost sync or rosserial_python is from different ros release than the rosserial client")
                     rospy.logerr("Mismatched protocol version in packet: lost sync or rosserial_python is from different ros release than the rosserial client")
-                    protocol_ver_msgs = {'\xff': 'Rev 0 (rosserial 0.4 and earlier)', '\xfe': 'Rev 1 (rosserial 0.5+)', '\xfd': 'Some future rosserial version'}
+                    protocol_ver_msgs = {'\xff': 'Rev 0 (rosserial 0.4 and earlier)', '\xfe': 'Rev 1 (rosserial 0.5+)', '\xfd': 'Rev 2', '\xfc': 'Some future rosserial version'}
                     if (flag[1] in protocol_ver_msgs):
                         found_ver_msg = 'Protocol version of client is ' + protocol_ver_msgs[flag[1]]
                     else:


### PR DESCRIPTION
This solves #237 

## Technical description of changes

This PR changes the protocol from this:
```
│MAGI│VERS│  SIZE   │CHKS│  TOPIC  │   MESSAGE   │CHKS│
│ ff │ fe │    ┆    │    │    ┆    │    ┆...┆    │    │
```
to this:
```
│ MAGIC NUMBER │VERS│  SIZE   │CHKS│NULL│  TOPIC  │NULL│   MESSAGE   │NULL│CHKS│
│ ff ┆ ff ┆ ff │ fd │    ┆    │    │ 00 │    ┆    │ 00 │    ┆...┆    │ 00 │    │
```

In addition, the message is encoded as such:
```
[ff ff ff] is escaped as [ff ff 00 ff]
[ff ff 00] is escaped as [ff ff 00 00]
```

Overhead goes up 5 bytes + the cost of encoding.

The size field refers to the size of the *encoded* message. Checksum is not affected by encoding (only null bytes are added).

## Rationale

Using that protocol, the [ff ff ff] sequence always and only appears at the start of every packet. That means that encountering the sequence automatically resets the state machine.

Before those changes, partial packets were not nicely handled. ros_lib's NodeHandle kept a timer per message, and resetted the state machine on timeouts. The timeout was set very low (20ms), so that if a message could not be read in one burst, spinOnce returned and the user program would likely make it timeout.

SImply increasing the timeout worked, but I wasn't satisfied with this solution.

I'm not sure how frequent partial packets are, and how big an hassle they can be, but at least they can now be correctly handled without timeout. ros_lib's NodeHandle's state machine has been adapted and the timeout was dropped.

## Test

A testing architecture is available there : https://github.com/Pikrass/test-rosserial-fd

## Work still to be done

rosserial_python and rosserial_server still don't handle partial packets. Changes to do so seem non-trivial, since these programs are able to read multiple bytes at once and don't use a state machine. However, the protocol now allows it.

There's in fact a minor regression. Before this PR, an unsync'ed server could hope to "catch up" when waiting for the first ff of a message. Now, because it requires three, more messages are likely to be dropped until, by chance, the three ffs align with the read. (That is easier to fix though.)