### PR TITLE
[python] fix an unboundlocalerror

### DIFF
--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -494,7 +494,7 @@ class SerialClient:
                 except IOError:
                     self.sendDiagnostics(diagnostic_msgs.msg.DiagnosticStatus.ERROR, "Packet Failed : Failed to read msg data")
                     rospy.loginfo("Packet Failed :  Failed to read msg data")
-                    rospy.loginfo("msg len is %d",len(msg))
+                    rospy.loginfo("expected msg length is %d", msg_length)
                     raise
 
                 # checksum for topic id and msg


### PR DESCRIPTION
This line always failed with _UnboundLocalError: local variable 'msg' referenced before assignment_.
When _tryRead_ method at l.493 raises exception, the method always returns without any return value. 
 So, _msg_ at l.497 never be assigned.
  