### PR TITLE
Add support for boolean parameters

### DIFF
--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -661,6 +661,24 @@ public:
     }
     return false;
   }
+  bool getParam(const char* name, bool* param, int length = 1, int timeout = 1000)
+  {
+    if (requestParam(name, timeout))
+    {
+      if (length == req_param_resp.ints_length)
+      {
+        //copy it over
+        for (int i = 0; i < length; i++)
+          param[i] = req_param_resp.ints[i];
+        return true;
+      }
+      else
+      {
+        logwarn("Failed to get param: length mismatch");
+      }
+    }
+    return false;
+  }
 };
 
 }

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -670,7 +670,7 @@ class SerialClient:
             if t!= type(p):
                 rospy.logerr('All Paramers in the list %s must be of the same type'%req.name)
                 return
-        if (t == int):
+        if (t == int or t == bool):
             resp.ints= param
         if (t == float):
             resp.floats=param


### PR DESCRIPTION
Trivial changes to support boolean parameters in rosserial_python and ros_lib.

Bools are simply passed as integers. That means if an user requests a parameter using a bool variable, but it turns out the param is really an int, this will convert it. Same thing the other way around. This behavior is different from, say, floats and ints, but I don't think it's an issue.