### PR TITLE
Fix compiling on boost > 1.66

### DIFF
--- a/rosserial_server/include/rosserial_server/udp_stream.h
+++ b/rosserial_server/include/rosserial_server/udp_stream.h
@@ -79,10 +79,20 @@ public:
     // If you get an error on the following line it means that your handler does
     // not meet the documented type requirements for a WriteHandler.
     BOOST_ASIO_WRITE_HANDLER_CHECK(WriteHandler, handler) type_check;
+#if !defined(BOOST_ASIO_ENABLE_OLD_SERVICES)
+    boost::asio::async_completion<WriteHandler,
+      void (boost::system::error_code, std::size_t)> init(handler);
 
+    this->get_service().async_send_to(
+        this->get_implementation(), buffers, client_endpoint_, 0,
+        init.completion_handler);
+
+    return init.result.get();
+#else // defined(BOOST_ASIO_ENABLE_OLD_SERVICES)
     return this->get_service().async_send_to(
         this->get_implementation(), buffers, client_endpoint_, 0,
         BOOST_ASIO_MOVE_CAST(WriteHandler)(handler));
+#endif
   }
 
   template <typename MutableBufferSequence, typename ReadHandler>
@@ -94,10 +104,19 @@ public:
     // If you get an error on the following line it means that your handler does
     // not meet the documented type requirements for a ReadHandler.
     BOOST_ASIO_READ_HANDLER_CHECK(ReadHandler, handler) type_check;
+#if !defined(BOOST_ASIO_ENABLE_OLD_SERVICES)
+    boost::asio::async_completion<ReadHandler,
+      void (boost::system::error_code, std::size_t)> init(handler);
 
+    this->get_service().async_receive(this->get_implementation(),
+        buffers, 0, init.completion_handler);
+
+    return init.result.get();
+#else // defined(BOOST_ASIO_ENABLE_OLD_SERVICES)
     return this->get_service().async_receive_from(
         this->get_implementation(), buffers, client_endpoint_, 0,
         BOOST_ASIO_MOVE_CAST(ReadHandler)(handler));
+#endif
   }
 
 private:

--- a/rosserial_server/include/rosserial_server/udp_stream.h
+++ b/rosserial_server/include/rosserial_server/udp_stream.h
@@ -80,6 +80,7 @@ public:
     // not meet the documented type requirements for a WriteHandler.
     BOOST_ASIO_WRITE_HANDLER_CHECK(WriteHandler, handler) type_check;
 #if (BOOST_VERSION >= 106600)
+    // See: http://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/net_ts.html
     boost::asio::async_completion<WriteHandler,
       void (boost::system::error_code, std::size_t)> init(handler);
 
@@ -88,7 +89,7 @@ public:
         init.completion_handler);
 
     return init.result.get();
-#else // defined(BOOST_ASIO_ENABLE_OLD_SERVICES)
+#else
     return this->get_service().async_send_to(
         this->get_implementation(), buffers, client_endpoint_, 0,
         BOOST_ASIO_MOVE_CAST(WriteHandler)(handler));
@@ -105,6 +106,7 @@ public:
     // not meet the documented type requirements for a ReadHandler.
     BOOST_ASIO_READ_HANDLER_CHECK(ReadHandler, handler) type_check;
 #if (BOOST_VERSION >= 106600)
+    // See: http://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/net_ts.html
     boost::asio::async_completion<ReadHandler,
       void (boost::system::error_code, std::size_t)> init(handler);
 
@@ -112,7 +114,7 @@ public:
         buffers, 0, init.completion_handler);
 
     return init.result.get();
-#else // defined(BOOST_ASIO_ENABLE_OLD_SERVICES)
+#else
     return this->get_service().async_receive_from(
         this->get_implementation(), buffers, client_endpoint_, 0,
         BOOST_ASIO_MOVE_CAST(ReadHandler)(handler));

--- a/rosserial_server/include/rosserial_server/udp_stream.h
+++ b/rosserial_server/include/rosserial_server/udp_stream.h
@@ -79,7 +79,7 @@ public:
     // If you get an error on the following line it means that your handler does
     // not meet the documented type requirements for a WriteHandler.
     BOOST_ASIO_WRITE_HANDLER_CHECK(WriteHandler, handler) type_check;
-#if !defined(BOOST_ASIO_ENABLE_OLD_SERVICES)
+#if (BOOST_VERSION >= 106600)
     boost::asio::async_completion<WriteHandler,
       void (boost::system::error_code, std::size_t)> init(handler);
 
@@ -104,7 +104,7 @@ public:
     // If you get an error on the following line it means that your handler does
     // not meet the documented type requirements for a ReadHandler.
     BOOST_ASIO_READ_HANDLER_CHECK(ReadHandler, handler) type_check;
-#if !defined(BOOST_ASIO_ENABLE_OLD_SERVICES)
+#if (BOOST_VERSION >= 106600)
     boost::asio::async_completion<ReadHandler,
       void (boost::system::error_code, std::size_t)> init(handler);
 


### PR DESCRIPTION
This PR fixes the breaking changes on `async_*` brought by Boost 1.66.0.