### PR TITLE
fix no attribute message_cache issue in message_info_service

### DIFF
--- a/rosserial_python/nodes/message_info_service.py
+++ b/rosserial_python/nodes/message_info_service.py
@@ -53,10 +53,10 @@ class MessageInfoService(object):
   def __init__(self):
     rospy.init_node("message_info_service")
     rospy.loginfo("rosserial message_info_service node")
-    self.service = rospy.Service("message_info", RequestMessageInfo, self._message_info_cb)
-    self.serviceInfoService = rospy.Service("service_info", RequestServiceInfo, self._service_info_cb)
     self.message_cache = {}
     self.service_cache = {}
+    self.service = rospy.Service("message_info", RequestMessageInfo, self._message_info_cb)
+    self.serviceInfoService = rospy.Service("service_info", RequestServiceInfo, self._service_info_cb)
 
   def _message_info_cb(self, req):
     package_message = tuple(req.type.split("/"))


### PR DESCRIPTION
Reorder the creation of attributes and services to prevent the _message_info_cb function is triggered before the message_cache attribute is created.  