### PR TITLE
add W5500 support for Arduino platform

### DIFF
--- a/rosserial_arduino/src/ros_lib/ArduinoTcpHardware.h
+++ b/rosserial_arduino/src/ros_lib/ArduinoTcpHardware.h
@@ -42,7 +42,7 @@
   #include <WiFi.h> // Using Espressif's WiFi.h
 #elif defined(W5500)
   #include <SPI.h>
-  #include <Ethernet.h>
+  #include <Ethernet2.h>
 #else
   #include <SPI.h>
   #include <Ethernet.h>

--- a/rosserial_arduino/src/ros_lib/ArduinoTcpHardware.h
+++ b/rosserial_arduino/src/ros_lib/ArduinoTcpHardware.h
@@ -40,6 +40,9 @@
   #include <ESP8266WiFi.h>
 #elif defined(ESP32)
   #include <WiFi.h> // Using Espressif's WiFi.h
+#elif defined(W5500)
+  #include <SPI.h>
+  #include <Ethernet.h>
 #else
   #include <SPI.h>
   #include <Ethernet.h>

--- a/rosserial_arduino/src/ros_lib/ros.h
+++ b/rosserial_arduino/src/ros_lib/ros.h
@@ -37,7 +37,7 @@
 
 #include "ros/node_handle.h"
 
-#if defined(ESP8266) or defined(ESP32) or defined(ROSSERIAL_ARDUINO_TCP)
+#if defined(ESP8266) or defined(ESP32) or defined(W5500) or defined(ROSSERIAL_ARDUINO_TCP)
   #include "ArduinoTcpHardware.h"
 #else
   #include "ArduinoHardware.h"


### PR DESCRIPTION
Arduino Ethernet shields use chip Wiznet W5100 and Ethernet library. 
Newest chip W5500 use Ethernet2 library, 