### PR TITLE
rosserial_python: handle service responses correctly

### DIFF
--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -170,9 +170,9 @@ class ServiceServer:
         data_buffer = StringIO.StringIO()
         req.serialize(data_buffer)
         self.response = None
-        if self.parent.send(self.id, data_buffer.getvalue()) >= 0:
-            while self.response is None:
-                pass
+        self.parent.send(self.id, data_buffer.getvalue())
+        while self.response is None:
+            time.sleep(0.001)
         return self.response
 
     def handlePacket(self, data):

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -170,8 +170,11 @@ class ServiceServer:
         data_buffer = StringIO.StringIO()
         req.serialize(data_buffer)
         self.response = None
+        self.error = False
         self.parent.send(self.id, data_buffer.getvalue())
         while self.response is None:
+            if self.error:
+                raise RuntimeError("Service call failed.")
             time.sleep(0.001)
         return self.response
 
@@ -780,7 +783,8 @@ class SerialClient(object):
                     try:
                         if isinstance(data, tuple):
                             topic, msg = data
-                            self._send(topic, msg)
+                            if self._send(topic, msg) < 0:
+                                self.error = True
                         elif isinstance(data, basestring):
                             self._write(data)
                         else:


### PR DESCRIPTION
`self.parent.send()` always returns None. Therefore we never waited for the service response and receive an error message `"ERROR: service [/topic] responded with an error: service cannot process request: service handler returned None"`

This PR also adds a small wait to reduce cpu load during waiting for the response.
This fixes #408.
