### PR TITLE
Add getparam handler for serial_node

### DIFF
--- a/rosserial_server/include/rosserial_server/session.h
+++ b/rosserial_server/include/rosserial_server/session.h
@@ -36,6 +36,7 @@
 #define ROSSERIAL_SERVER_SESSION_H
 
 #include <map>
+#include <typeinfo>
 #include <boost/bind.hpp>
 #include <boost/asio.hpp>
 #include <boost/function.hpp>
@@ -44,6 +45,7 @@
 #include <ros/ros.h>
 #include <rosserial_msgs/TopicInfo.h>
 #include <rosserial_msgs/Log.h>
+#include <rosserial_msgs/RequestParam.h>
 #include <topic_tools/shape_shifter.h>
 #include <std_msgs/Time.h>
 
@@ -108,7 +110,9 @@ public:
         = boost::bind(&Session::handle_log, this, _1);
     callbacks_[rosserial_msgs::TopicInfo::ID_TIME]
         = boost::bind(&Session::handle_time, this, _1);
-
+    callbacks_[rosserial_msgs::TopicInfo::ID_PARAMETER_REQUEST]
+        = boost::bind(&Session::handle_param, this, _1);
+        
     active_ = true;
     attempt_sync();
     read_sync_header();
@@ -480,6 +484,76 @@ private:
     // The MCU requesting the time from the server is the sync notification. This
     // call moves the timeout forward.
     set_sync_timeout(timeout_interval_);
+  }
+  
+  void handle_param(ros::serialization::IStream& stream)
+  {
+    rosserial_msgs::RequestParamRequest req;
+    ros::serialization::Serializer<rosserial_msgs::RequestParamRequest>::read(stream, req);
+
+    if (ros::param::has(req.name.c_str())) {
+      ROS_INFO("Parameter %s requested.", req.name.c_str());
+
+      rosserial_msgs::RequestParamResponse resp;
+      XmlRpc::XmlRpcValue param_value;
+      if (ros::param::get(req.name.c_str(), param_value)) {
+        switch (param_value.getType()) {
+          case XmlRpc::XmlRpcValue::TypeInt:
+            ROS_DEBUG("%s is type int: %d", req.name.c_str(), static_cast<int>(param_value));
+            resp.ints.push_back(static_cast<int32_t>(param_value));
+            break;
+          case XmlRpc::XmlRpcValue::TypeDouble:
+            ROS_DEBUG("%s is type float: %f", req.name.c_str(), static_cast<double>(param_value));
+            resp.floats.push_back(static_cast<float>(static_cast<double>(param_value)));
+            break;
+          case XmlRpc::XmlRpcValue::TypeString:
+            ROS_DEBUG("%s is type string: %s", req.name.c_str(), static_cast<std::string>(param_value).c_str());
+            resp.strings.push_back(static_cast<std::string>(param_value));
+            break;
+          case XmlRpc::XmlRpcValue::TypeArray:
+            ROS_DEBUG("%s is type array.", req.name.c_str());
+            if (param_value.size() > 0) {
+              // Let's assume array type is the same as first element
+              XmlRpc::XmlRpcValue::Type array_type = param_value[0].getType();
+              for (int i = 0; i < param_value.size(); ++i) 
+              {
+                if (param_value[i].getType() != array_type) {
+                  ROS_WARN("Parameter of array mixed type not handled: %s", req.name.c_str());
+                  return;
+                }
+                switch (param_value[i].getType()) {
+                  case XmlRpc::XmlRpcValue::TypeInt:
+                    resp.ints.push_back(static_cast<int32_t>(param_value[i]));
+                    break;
+                  case XmlRpc::XmlRpcValue::TypeDouble:
+                    resp.floats.push_back(static_cast<float>(static_cast<double>(param_value[i])));
+                    break;
+                  case XmlRpc::XmlRpcValue::TypeString:
+                    resp.strings.push_back(static_cast<std::string>(param_value[i]));
+                    break;
+                }
+              }
+            } else {
+              ROS_WARN("Parameter array %s is empty.", req.name.c_str());
+            }
+            break;
+          default:
+            ROS_WARN("Parameter type not handled: %s", req.name.c_str());
+            return;
+        }
+        // Send response
+        size_t length = ros::serialization::serializationLength(resp);
+        std::vector<uint8_t> message(length);
+        ros::serialization::OStream ostream(&message[0], length);
+        ros::serialization::Serializer<rosserial_msgs::RequestParamResponse>::write(ostream, resp);
+        write_message(message, rosserial_msgs::TopicInfo::ID_PARAMETER_REQUEST);
+        set_sync_timeout(timeout_interval_);
+      } else {
+        ROS_WARN("Parameter %s does not exist", req.name.c_str());
+      }
+    } else {
+      ROS_WARN("Parameter %s does not exist", req.name.c_str());
+    }
   }
 
   Socket socket_;


### PR DESCRIPTION
This PR adds ability for the rosserial slaves to access the ros parameters.
The original author of this change is @vmatos . I am just helping to upstream it because he is lack of free time:
https://github.com/vmatos/rosserial/commit/7e3333ebd5e7a3996027b41cb51d6051a350d480#commitcomment-30454859

