### PR TITLE
Fix travis build failure due to the "archive has premature member" er…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - sudo sh -c 'echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update
+  - sudo apt-get install dpkg -y
   - sudo apt-get install python-rosdep -y
   - sudo rosdep init
   - rosdep update


### PR DESCRIPTION
Fix travis build failure due to the "archive has premature member" errors
by upgrading the dpkg before installing ROS packages.
See:
https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627