### PR TITLE
Publisher: Fail gracefully instead of segfaulting when not advertised

### DIFF
--- a/rosserial_client/src/ros_lib/ros/publisher.h
+++ b/rosserial_client/src/ros_lib/ros/publisher.h
@@ -48,10 +48,15 @@ public:
   Publisher(const char * topic_name, Msg * msg, int endpoint = rosserial_msgs::TopicInfo::ID_PUBLISHER) :
     topic_(topic_name),
     msg_(msg),
-    endpoint_(endpoint) {};
+    nh_(nullptr),
+    endpoint_(endpoint)
+    {};
 
   int publish(const Msg * msg)
   {
+    if(nullptr == nh_)
+        return -1;
+    
     return nh_->publish(id_, msg);
   };
   int getEndpointType()
@@ -61,7 +66,7 @@ public:
 
   const char * topic_;
   Msg *msg_;
-  // id_ and no_ are set by NodeHandle when we advertise
+  // id_ and nh_ are set by NodeHandle when we advertise
   int id_;
   NodeHandleBase_* nh_;
 
@@ -72,3 +77,4 @@ private:
 }
 
 #endif
+


### PR DESCRIPTION
Adds a nullptr check before using `_nh`. This prevents segfaults (or stranger stuff depending on where `_nh` happens to point to :D) when publish is called before advertise.
