### PR TITLE
Change the access modifiers "private" to "protected" in NodeHandle_

### DIFF
--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -548,7 +548,7 @@ public:
    * Logging
    */
 
-private:
+protected:
   void log(char byte, const char * msg)
   {
     rosserial_msgs::Log l;
@@ -583,7 +583,7 @@ public:
    * Parameters
    */
 
-private:
+protected:
   bool param_recieved;
   rosserial_msgs::RequestParamResponse req_param_resp;
 


### PR DESCRIPTION
Several member functions in `NodeHandle_` can be overwritten (e.g. `spinOnce`), so this class was designed to afford the potential derivation usage. However, it is impossible to access to the private variables prevents from the derived class (This is the problem what I am facing with). So I recommend to change the variables to be `protected `.