### PR TITLE
Add rosservice server function in rosserial_server.

### DIFF
--- a/rosserial_server/CMakeLists.txt
+++ b/rosserial_server/CMakeLists.txt
@@ -6,12 +6,25 @@ find_package(catkin REQUIRED COMPONENTS
   rosserial_msgs
   std_msgs
   topic_tools
+  message_generation
 )
 
 find_package(Boost REQUIRED COMPONENTS
   system
   thread
 )
+
+add_message_files(
+  FILES
+  SerializedMessage.msg
+)
+
+
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
+
 
 catkin_package(
   INCLUDE_DIRS include
@@ -31,17 +44,17 @@ include_directories(
 add_executable(${PROJECT_NAME}_serial_node src/serial_node.cpp)
 target_link_libraries(${PROJECT_NAME}_serial_node ${catkin_LIBRARIES})
 set_target_properties(${PROJECT_NAME}_serial_node PROPERTIES OUTPUT_NAME serial_node PREFIX "")
-add_dependencies(${PROJECT_NAME}_serial_node ${catkin_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME}_serial_node ${catkin_EXPORTED_TARGETS} ${${PROJECT_NAME}_EXPORTED_TARGETS})
 
 add_executable(${PROJECT_NAME}_socket_node src/socket_node.cpp)
 target_link_libraries(${PROJECT_NAME}_socket_node ${catkin_LIBRARIES})
 set_target_properties(${PROJECT_NAME}_socket_node PROPERTIES OUTPUT_NAME socket_node PREFIX "")
-add_dependencies(${PROJECT_NAME}_socket_node ${catkin_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME}_socket_node ${catkin_EXPORTED_TARGETS}  ${${PROJECT_NAME}_EXPORTED_TARGETS})
 
 add_executable(${PROJECT_NAME}_udp_socket_node src/udp_socket_node.cpp)
 target_link_libraries(${PROJECT_NAME}_udp_socket_node ${catkin_LIBRARIES})
 set_target_properties(${PROJECT_NAME}_udp_socket_node PROPERTIES OUTPUT_NAME udp_socket_node PREFIX "")
-add_dependencies(${PROJECT_NAME}_udp_socket_node ${catkin_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME}_udp_socket_node ${catkin_EXPORTED_TARGETS}  ${${PROJECT_NAME}_EXPORTED_TARGETS})
 
 install(
   TARGETS

--- a/rosserial_server/launch/serial.launch
+++ b/rosserial_server/launch/serial.launch
@@ -4,4 +4,6 @@
     <param name="port" value="$(arg port)" />
   </node>
   <node pkg="rosserial_python" type="message_info_service.py" name="rosserial_message_info" />
+
+  <node pkg="rosserial_server" type="rosservice_server_manager.py" name="" output="screen" />
 </launch>

--- a/rosserial_server/msg/SerializedMessage.msg
+++ b/rosserial_server/msg/SerializedMessage.msg
@@ -1,0 +1,2 @@
+uint16 id
+uint8[] body

--- a/rosserial_server/package.xml
+++ b/rosserial_server/package.xml
@@ -17,9 +17,11 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>topic_tools</build_depend>
+  <build_depend>message_generation</build_depend>
   <run_depend>rosserial_msgs</run_depend>
   <run_depend>rosserial_python</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>topic_tools</run_depend>
+  <run_depend>message_runtime</run_depend>
 </package>

--- a/rosserial_server/scripts/rosservice_server_manager.py
+++ b/rosserial_server/scripts/rosservice_server_manager.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+
+#####################################################################
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2017, JSK Lab
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+__author__ = "chou@jsk.imi.i.u-tokyo.ac.jp (Moju Zhao)"
+
+import roslib
+import rospy
+from serial import *
+import StringIO
+from spinal_ros_bridge.msg import *
+from rosserial_msgs.msg import *
+import struct
+
+def load_pkg_module(package, directory):
+    #check if its in the python path
+    path = sys.path
+    try:
+        imp.find_module(package)
+    except:
+        roslib.load_manifest(package)
+    try:
+        m = __import__( package + '.' + directory )
+    except:
+        rospy.logerr( "Cannot import package : %s"% package )
+        rospy.logerr( "sys.path was " + str(path) )
+        return None
+    return m
+
+
+class ServiceServer:
+    """
+        ServiceServer responds to requests from ROS.
+    """
+
+    def __init__(self, topic_info, parent):
+        self.topic = topic_info.topic_name
+        self.parent = parent
+
+        # find message type
+        package, service = topic_info.message_type.split('/')
+        s = load_pkg_module(package, 'srv')
+        s = getattr(s, 'srv')
+        self.mreq = getattr(s, service+"Request")
+        self.mres = getattr(s, service+"Response")
+        srv = getattr(s, service)
+        self.service = rospy.Service(self.topic, srv, self.callback)
+
+        # response message
+        self.data = None
+
+    def unregister(self):
+        rospy.loginfo("Removing service: %s", self.topic)
+        self.service.shutdown()
+
+    def callback(self, req):
+        """ Forward request to serial device. """
+        data_buffer = StringIO.StringIO()
+        req.serialize(data_buffer)
+        self.response = None
+        self.parent.serializedMsgsPublish(self.id, data_buffer.getvalue())
+
+        # rosserive server in rospy is exected in an isolated thread.
+        while self.response == None:
+            pass
+        return self.response
+
+    def handlePacket(self, data):
+        """ Forward response to ROS network. """
+        r = self.mres()
+        r.deserialize(data)
+        self.response = r
+
+class RosserviceServerManager:
+    def __init__(self):
+        self.pub_serialized_srv_req = rospy.Publisher('/serialized_srv_req', SerializedMessage, queue_size=10)
+        self.sub_serialized_msg = rospy.Subscriber('/serialized_msg', SerializedMessage, self.serializedMsgsCallback)
+        self.services = dict()    # topic:Service
+        self.callbacks = dict()
+        self.callbacks[TopicInfo.ID_SERVICE_SERVER+TopicInfo.ID_PUBLISHER] = self.setupServiceServerPublisher
+        self.callbacks[TopicInfo.ID_SERVICE_SERVER+TopicInfo.ID_SUBSCRIBER] = self.setupServiceServerSubscriber
+
+    def serializedMsgsCallback(self, msg):
+        self.callbacks[msg.id](msg.body)
+
+    def serializedMsgsPublish(self, id, data):
+        msg = SerializedMessage()
+        msg.id = id
+        msg.body = data
+        self.pub_serialized_srv_req.publish(msg);
+
+    def setupServiceServerPublisher(self, data):
+        """ Register a new service server. """
+        try:
+            msg = TopicInfo()
+            msg.deserialize(data)
+            try:
+                srv = self.services[msg.topic_name]
+            except:
+                srv = ServiceServer(msg, self)
+                rospy.loginfo("Setup service server on %s [%s]" % (msg.topic_name, msg.message_type) )
+                self.services[msg.topic_name] = srv
+            if srv.mres._md5sum == msg.md5sum:
+                self.callbacks[msg.topic_id] = srv.handlePacket
+            else:
+                raise Exception('Checksum does not match: ' + srv.mres._md5sum + ',' + msg.md5sum)
+        except Exception as e:
+            rospy.logerr("Creation of service server failed: %s", e)
+
+    def setupServiceServerSubscriber(self, data):
+        """ Register a new service server. """
+
+        try:
+            msg = TopicInfo()
+            msg.deserialize(data)
+            try:
+                srv = self.services[msg.topic_name]
+            except:
+                srv = ServiceServer(msg, self)
+                rospy.loginfo("Setup service server on %s [%s]" % (msg.topic_name, msg.message_type) )
+                self.services[msg.topic_name] = srv
+            if srv.mreq._md5sum == msg.md5sum:
+                srv.id = msg.topic_id
+            else:
+                raise Exception('Checksum does not match: ' + srv.mreq._md5sum + ',' + msg.md5sum)
+        except Exception as e:
+            rospy.logerr("Creation of service server failed: %s", e)
+
+if __name__=="__main__":
+
+    rospy.init_node("rosservice_server_manager")
+    manager = RosserviceServerManager()
+    rospy.spin()


### PR DESCRIPTION
So far, the rosservice server function is not implemented in rosserial_server,  since c/c++ is static typing.
Thus, it is difficult to do like python: https://github.com/ros-drivers/rosserial/blob/melodic-devel/rosserial_python/src/rosserial_python/SerialClient.py#L153-L159

However, it is quite inconvenient  that there is no rosservice server in c/c++ mode. 

This PR is aimed to achieve the rosservice server by adding an additional python script:
`rosserial_server/rosservice_server_manager.py`, which is  the  extracted part from `rosserial_python/SerialClient.py`. This script communicates with `rosserial_server/session.h` by a new message: `SerializedMessage.msg`. 

I have testified with arduino sample: `ServiceServer`.

I know the duplication of the existing code is not clever. Maybe it is better to derive from `rosserial_python/SerialClient.py`.


