### PR TITLE
Fix reconnection of rosserial-python

### DIFF
--- a/rosserial_python/nodes/serial_node.py
+++ b/rosserial_python/nodes/serial_node.py
@@ -95,4 +95,9 @@ if __name__=="__main__":
             except OSError:
                 sleep(1.0)
                 continue
+            except:
+                rospy.logwarn("Unexpected Error.%s", sys.exc_info()[0])
+                client.port.close()
+                sleep(1.0)
+                continue
 


### PR DESCRIPTION
Related to #262 
Add handling unexpected execption by disconnecting serial port.