### PR TITLE
Add serial communication for ESP controllers 

### DIFF
--- a/rosserial_arduino/src/ros_lib/ros.h
+++ b/rosserial_arduino/src/ros_lib/ros.h
@@ -37,7 +37,7 @@
 
 #include "ros/node_handle.h"
 
-#if defined(ESP8266) or defined(ESP32) or defined(ROSSERIAL_ARDUINO_TCP)
+#if (defined(ESP8266) or defined(ESP32) or defined(ROSSERIAL_ARDUINO_TCP)) and not defined(ESP_SERIAL)
   #include "ArduinoTcpHardware.h"
 #else
   #include "ArduinoHardware.h"


### PR DESCRIPTION
Hello, 

## reason: 

Due to the clock frequency, I decided to use an ESP, but for personal reason I prefer to use it by USB serial. 

May be, this option can help someone. 

## use: 
- define ESP_SERIAL: use the esp in "serial mode"
- not define ESP_SERIAL: use the esp in "tcp mode"

## test: 
- ros version: melodic 
- boards tested: ESP32 and ESP8266 

