### PR TITLE
Fix bug: assign the md5 for service

### DIFF
--- a/rosserial_server/include/rosserial_server/topic_handlers.h
+++ b/rosserial_server/include/rosserial_server/topic_handlers.h
@@ -140,6 +140,7 @@ public:
     {
       ROS_WARN_STREAM("Unable to look up service definition: " << e.what());
     }
+    service_md5_ = srvinfo.md5sum;
     request_message_md5_ = reqinfo.md5sum;
     response_message_md5_ = respinfo.md5sum;
 
@@ -151,6 +152,9 @@ public:
   }
   void setTopicId(uint16_t topic_id) {
     topic_id_ = topic_id;
+  }
+  std::string getServiceMD5() {
+    return service_md5_;
   }
   std::string getRequestMessageMD5() {
     return request_message_md5_;


### PR DESCRIPTION
Fix the bug related to #446 .

`serivce_md5_` is used in following function:
https://github.com/tongtybj/rosserial/blob/9f9ab3ee71e00e48c69032096ec9e96f896a9724/rosserial_server/include/rosserial_server/topic_handlers.h#L173