### PR TITLE
Fix makedirs error

### DIFF
--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -572,7 +572,11 @@ def rosserial_generate(rospack, path, mapping):
     print('\n')
 
 def rosserial_client_copy_files(rospack, path):
+    if os.path.exists(path+"/ros"):
+        shutil.rmtree(path+"/ros")
     os.makedirs(path+"/ros")
+    if os.path.exists(path+"/tf"):
+        shutil.rmtree(path+"/tf")
     os.makedirs(path+"/tf")
     files = ['duration.cpp',
              'time.cpp',


### PR DESCRIPTION
If you previously generated the libraries in your project you couldn't regenerate them because this script would try to create an existing directory.
Now it checks if the directory is already present and, in that case, it deletes the folder before recreating it