### PR TITLE
[Windows] use c++ signed trait to replace ssize_t for better portability.

### DIFF
--- a/rosserial_server/include/rosserial_server/async_read_buffer.h
+++ b/rosserial_server/include/rosserial_server/async_read_buffer.h
@@ -40,6 +40,10 @@
 
 #include <ros/ros.h>
 
+#include <cstdint> // size_t
+#include <type_traits> // std::make_signed
+typedef std::make_signed<size_t>::type signed_size_t;
+
 namespace rosserial_server
 {
 
@@ -78,7 +82,7 @@ public:
     }
 
     // Number of bytes which must be transferred to satisfy the request.
-    ssize_t transfer_bytes = read_requested_bytes_ - bytesAvailable();
+    signed_size_t transfer_bytes = read_requested_bytes_ - bytesAvailable();
 
     if (transfer_bytes > 0)
     {

--- a/rosserial_server/include/rosserial_server/async_read_buffer.h
+++ b/rosserial_server/include/rosserial_server/async_read_buffer.h
@@ -40,6 +40,7 @@
 
 #include <ros/ros.h>
 
+// ssize_t is POSIX-only type. Use make_signed for portable code.
 #include <cstdint> // size_t
 #include <type_traits> // std::make_signed
 typedef std::make_signed<size_t>::type signed_size_t;


### PR DESCRIPTION
The `ssize_t` is a type defined in POSIX standard. However, on non-POSIX system (for example, Windows), this could be absent.

This change is inspired by an alternative being talked about in this conclusion: [`LWG issue: 2251. C++ library should define ssize_t`](https://cplusplus.github.io/LWG/issue2251), which mentions that this can be achieved by C++11 type trait feature.