### PR TITLE
Support SAMD21.

### DIFF
--- a/rosserial_arduino/src/ros_lib/ArduinoHardware.h
+++ b/rosserial_arduino/src/ros_lib/ArduinoHardware.h
@@ -70,7 +70,9 @@ class ArduinoHardware {
     }
     ArduinoHardware()
     {
-#if defined(USBCON) and !(defined(USE_USBCON))
+#if defined(_SAMD21_) and defined(USE_USBCON)
+      iostream=&SerialUSB;
+#elif defined(USBCON) and !(defined(USE_USBCON))
       /* Leonardo support */
       iostream = &Serial1;
 #elif defined(USE_TEENSY_HW_SERIAL) or defined(USE_STM32_HW_SERIAL)


### PR DESCRIPTION
Issue: When compiling code, e.g., [HelloWorld](https://github.com/ros-drivers/rosserial/blob/melodic-devel/rosserial_arduino/src/ros_lib/examples/HelloWorld/HelloWorld.pde), on an Arduino Zero with SAMD21 microprocessor with `#define USE_USBCON`, the compilation failed stating `error: cannot convert 'Uart*' to 'Serial_*' in assignment` (see https://github.com/ros-drivers/rosserial/issues/376).

This PR adds the necessary iostream to communicate through the native USB connection.

Tested on HelloWorld example.