### PR TITLE
Allow client change port

### DIFF
--- a/rosserial_arduino/src/ros_lib/ArduinoHardware.h
+++ b/rosserial_arduino/src/ros_lib/ArduinoHardware.h
@@ -84,6 +84,10 @@ class ArduinoHardware {
       this->iostream = h.iostream;
       this->baud_ = h.baud_;
     }
+
+    void setPort(SERIAL_CLASS* io){
+      this->iostream = io;
+    }
   
     void setBaud(long baud){
       this->baud_= baud;


### PR DESCRIPTION
Allow client main function change Serial port.
For many current hardware boards is very common to have many serial ports. 
Currently if someone wants to change serial port need to change it in library code.
This patch creates a setPort member in ArduinoHardware to expose this functionality.

Example in arduino setup()

  Serial2.begin(230400, SERIAL_8N1, RXD2, TXD2);  // set pins for serial2 in ESP
  delay(500);

  nh.getHardware()->setBaud(230400);   // set baud rate other than default (current available)
  nh.getHardware()->setPort(&Serial2);   // set port other than default not changing library code (proposed change)

  nh.initNode();
  broadcaster.init(nh);