### PR TITLE
rosserial_python: Catch exception with 'as' instead of comma

### DIFF
--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -311,7 +311,7 @@ class RosSerialServer:
             if chunk == '':
                 raise RuntimeError("RosSerialServer.inWaiting() socket connection broken")
             return len(chunk)
-        except socket.error, e:
+        except socket.error as e:
             if e.args[0] == errno.EWOULDBLOCK:
                 return 0
             raise


### PR DESCRIPTION
See https://stackoverflow.com/questions/2535760/python-try-except-comma-vs-as-in-except.

Python 3 enforces the usage of `as`, so fix it here.