### PR TITLE
Use arduino packet write function.

### DIFF
--- a/rosserial_arduino/src/ros_lib/ArduinoHardware.h
+++ b/rosserial_arduino/src/ros_lib/ArduinoHardware.h
@@ -101,8 +101,7 @@ class ArduinoHardware {
 
     int read(){return iostream->read();};
     void write(uint8_t* data, int length){
-      for(int i=0; i<length; i++)
-        iostream->write(data[i]);
+      iostream->write(data, length);
     }
 
     unsigned long time(){return millis();}


### PR DESCRIPTION
Users have observed that they cannot publish large ROS messages on an Arduino at a high rate https://github.com/ros-drivers/rosserial/issues/277. Their workaround was to create custom messages with minimized size.

We timed the [publish function](https://github.com/ros-drivers/rosserial/blob/melodic-devel/rosserial_client/src/ros_lib/ros/node_handle.h#L511-L545) and realized that [serial writing](https://github.com/ros-drivers/rosserial/blob/melodic-devel/rosserial_client/src/ros_lib/ros/node_handle.h#L537) takes the major share.

Publishing messages in packets rather than character by character [speeds up serial transmission](https://forum.arduino.cc/index.php?topic=575333.0) significantly. 

Here we publish IMU messages (320 bytes) on a SAMD21 microcontroller through native USB and time the serial write function.

Sending bytewise about 9000us per message (~284 kb/s) (**old**)
![serial_write_broken](https://user-images.githubusercontent.com/11293852/77487279-59121980-6e32-11ea-990a-afd19a0b6864.png)

Sending packetwise about 450us per message (~5.689 Mb/s) (**new**)
![serial_write_fixed](https://user-images.githubusercontent.com/11293852/77487337-8959b800-6e32-11ea-8c20-b09f01db2f91.png)

May also be relevant to @floriantschopp
