### PR TITLE
Graceful shutdown

### DIFF
--- a/rosserial_server/include/rosserial_server/serial_session.h
+++ b/rosserial_server/include/rosserial_server/serial_session.h
@@ -72,6 +72,10 @@ private:
       timer_.expires_from_now(boost::posix_time::milliseconds(2000));
       timer_.async_wait(boost::bind(&SerialSession::check_connection, this));
     }
+    else
+    {
+      shutdown();
+    }
   }
 
   void attempt_connection()

--- a/rosserial_server/include/rosserial_server/session.h
+++ b/rosserial_server/include/rosserial_server/session.h
@@ -61,7 +61,8 @@ class Session : boost::noncopyable
 {
 public:
   Session(boost::asio::io_service& io_service)
-    : socket_(io_service),
+    : io_service_(io_service),
+      socket_(io_service),
       sync_timer_(io_service),
       require_check_timer_(io_service),
       ros_spin_timer_(io_service),
@@ -165,6 +166,10 @@ private:
       ros_spin_timer_.expires_from_now(ros_spin_interval_);
       ros_spin_timer_.async_wait(boost::bind(&Session::ros_spin_timeout, this,
                                              boost::asio::placeholders::error));
+    }
+    else
+    {
+      io_service_.stop();
     }
   }
 
@@ -482,6 +487,7 @@ private:
     set_sync_timeout(timeout_interval_);
   }
 
+  boost::asio::io_service& io_service_;
   Socket socket_;
   AsyncReadBuffer<Socket> async_read_buffer_;
   enum { buffer_max = 1023 };

--- a/rosserial_server/include/rosserial_server/session.h
+++ b/rosserial_server/include/rosserial_server/session.h
@@ -139,7 +139,9 @@ public:
   void shutdown()
   {
     if (is_active())
+    {
       stop();
+    }
     io_service_.stop();
   }
 

--- a/rosserial_server/include/rosserial_server/session.h
+++ b/rosserial_server/include/rosserial_server/session.h
@@ -136,6 +136,13 @@ public:
     active_ = false;
   }
 
+  void shutdown()
+  {
+    if (is_active())
+      stop();
+    io_service_.stop();
+  }
+
   bool is_active()
   {
     return active_;
@@ -169,7 +176,7 @@ private:
     }
     else
     {
-      io_service_.stop();
+      shutdown();
     }
   }
 
@@ -315,6 +322,10 @@ private:
       sync_timer_.expires_from_now(interval);
       sync_timer_.async_wait(boost::bind(&Session::sync_timeout, this,
             boost::asio::placeholders::error));
+    }
+    else
+    {
+      shutdown();
     }
   }
 

--- a/rosserial_server/include/rosserial_server/udp_socket_session.h
+++ b/rosserial_server/include/rosserial_server/udp_socket_session.h
@@ -78,6 +78,10 @@ private:
       timer_.expires_from_now(boost::posix_time::milliseconds(2000));
       timer_.async_wait(boost::bind(&UdpSocketSession::check_connection, this));
     }
+    else
+    {
+      shutdown();
+    }
   }
 
   boost::asio::deadline_timer timer_;


### PR DESCRIPTION
Call io_service.stop() when ros::ok() returns false