### PR TITLE
Fixes for new warnings/behaviours in GCC7+/cppcheck.

### DIFF
--- a/rosserial_client/src/ros_lib/ros/msg.h
+++ b/rosserial_client/src/ros_lib/ros/msg.h
@@ -53,7 +53,7 @@ public:
   /**
    * @brief This tricky function handles promoting a 32bit float to a 64bit
    *        double, so that AVR can publish messages containing float64
-   *        fields, despite AVV having no native support for double.
+   *        fields, despite AVR having no native support for double.
    *
    * @param[out] outbuffer pointer for buffer to serialize to.
    * @param[in] f value to serialize.
@@ -63,7 +63,11 @@ public:
    */
   static int serializeAvrFloat64(unsigned char* outbuffer, const float f)
   {
-    const int32_t* val = (int32_t*) &f;
+    // Cast through void* to silence a GCC warning about this being a
+    // non-portable cast (we don't care, it only has to work on AVR).
+    const void* vval = reinterpret_cast<const void*>(&f);
+    const int32_t* val = reinterpret_cast<const int32_t*>(vval);
+
     int32_t exp = ((*val >> 23) & 255);
     if (exp != 0)
     {
@@ -101,7 +105,10 @@ public:
    */
   static int deserializeAvrFloat64(const unsigned char* inbuffer, float* f)
   {
-    uint32_t* val = (uint32_t*)f;
+    // Cast through void* to silence a GCC warning about this being a
+    // non-portable cast (we don't care, it only has to work on AVR).
+    void* vval = reinterpret_cast<void*>(f);
+    uint32_t* val = reinterpret_cast<uint32_t*>(vval);
     inbuffer += 3;
 
     // Copy truncated mantissa.

--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -104,19 +104,19 @@ template<class Hardware,
 class NodeHandle_ : public NodeHandleBase_
 {
 protected:
-  Hardware hardware_;
+  Hardware hardware_{};
 
   /* time used for syncing */
-  uint32_t rt_time;
+  uint32_t rt_time{0};
 
   /* used for computing current time */
-  uint32_t sec_offset, nsec_offset;
+  uint32_t sec_offset{0}, nsec_offset{0};
 
   /* Spinonce maximum work timeout */
-  uint32_t spin_timeout_;
+  uint32_t spin_timeout_{0};
 
-  uint8_t message_in[INPUT_SIZE];
-  uint8_t message_out[OUTPUT_SIZE];
+  uint8_t message_in[INPUT_SIZE] = {0};
+  uint8_t message_out[OUTPUT_SIZE] = {0};
 
   Publisher * publishers[MAX_PUBLISHERS];
   Subscriber_ * subscribers[MAX_SUBSCRIBERS];
@@ -125,31 +125,6 @@ protected:
    * Setup Functions
    */
 public:
-  NodeHandle_() : configured_(false)
-  {
-
-    for (unsigned int i = 0; i < MAX_PUBLISHERS; i++)
-      publishers[i] = 0;
-
-    for (unsigned int i = 0; i < MAX_SUBSCRIBERS; i++)
-      subscribers[i] = 0;
-
-    for (unsigned int i = 0; i < INPUT_SIZE; i++)
-      message_in[i] = 0;
-
-    for (unsigned int i = 0; i < OUTPUT_SIZE; i++)
-      message_out[i] = 0;
-
-    req_param_resp.ints_length = 0;
-    req_param_resp.ints = NULL;
-    req_param_resp.floats_length = 0;
-    req_param_resp.floats = NULL;
-    req_param_resp.ints_length = 0;
-    req_param_resp.ints = NULL;
-
-    spin_timeout_ = 0;
-  }
-
   Hardware* getHardware()
   {
     return &hardware_;
@@ -189,19 +164,19 @@ public:
   }
 
 protected:
-  //State machine variables for spinOnce
-  int mode_;
-  int bytes_;
-  int topic_;
-  int index_;
-  int checksum_;
+  // State machine variables for spinOnce
+  int mode_{0};
+  int bytes_{0};
+  int topic_{0};
+  int index_{0};
+  int checksum_{0};
 
-  bool configured_;
+  bool configured_{false};
 
   /* used for syncing the time */
-  uint32_t last_sync_time;
-  uint32_t last_sync_receive_time;
-  uint32_t last_msg_timeout_time;
+  uint32_t last_sync_time{0};
+  uint32_t last_sync_receive_time{0};
+  uint32_t last_msg_timeout_time{0};
 
 public:
   /* This function goes in your loop() function, it handles
@@ -333,7 +308,7 @@ public:
           else if (topic_ == TopicInfo::ID_PARAMETER_REQUEST)
           {
             req_param_resp.deserialize(message_in);
-            param_recieved = true;
+            param_received = true;
           }
           else if (topic_ == TopicInfo::ID_TX_STOP)
           {
@@ -584,17 +559,17 @@ public:
    */
 
 protected:
-  bool param_recieved;
-  rosserial_msgs::RequestParamResponse req_param_resp;
+  bool param_received{false};
+  rosserial_msgs::RequestParamResponse req_param_resp{};
 
   bool requestParam(const char * name, int time_out =  1000)
   {
-    param_recieved = false;
+    param_received = false;
     rosserial_msgs::RequestParamRequest req;
     req.name  = (char*)name;
     publish(TopicInfo::ID_PARAMETER_REQUEST, &req);
     uint32_t end_time = hardware_.time() + time_out;
-    while (!param_recieved)
+    while (!param_received)
     {
       spinOnce();
       if (hardware_.time() > end_time)

--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -209,7 +209,7 @@ public:
    */
 
 
-  virtual int spinOnce()
+  virtual int spinOnce() override
   {
     /* restart if timed out */
     uint32_t c_time = hardware_.time();
@@ -360,7 +360,7 @@ public:
 
 
   /* Are we connected to the PC? */
-  virtual bool connected()
+  virtual bool connected() override
   {
     return configured_;
   };
@@ -399,7 +399,7 @@ public:
     return current_time;
   }
 
-  void setNow(Time & new_now)
+  void setNow(const Time & new_now)
   {
     uint32_t ms = hardware_.time();
     sec_offset = new_now.sec - ms / 1000 - 1;
@@ -508,7 +508,7 @@ public:
     configured_ = true;
   }
 
-  virtual int publish(int id, const Msg * msg)
+  virtual int publish(int id, const Msg * msg) override
   {
     if (id >= 100 && !configured_)
       return 0;

--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -118,8 +118,8 @@ protected:
   uint8_t message_in[INPUT_SIZE] = {0};
   uint8_t message_out[OUTPUT_SIZE] = {0};
 
-  Publisher * publishers[MAX_PUBLISHERS];
-  Subscriber_ * subscribers[MAX_SUBSCRIBERS];
+  Publisher * publishers[MAX_PUBLISHERS] = {nullptr};
+  Subscriber_ * subscribers[MAX_SUBSCRIBERS] {nullptr};
 
   /*
    * Setup Functions

--- a/rosserial_client/src/ros_lib/ros/service_client.h
+++ b/rosserial_client/src/ros_lib/ros/service_client.h
@@ -54,7 +54,7 @@ public:
     this->waiting = true;
   }
 
-  virtual void call(const MReq & request, MRes & response)
+  virtual void call(const MReq & request, MRes & response) override
   {
     if (!pub.nh_->connected()) return;
     ret = &response;
@@ -65,20 +65,20 @@ public:
   }
 
   // these refer to the subscriber
-  virtual void callback(unsigned char *data)
+  virtual void callback(unsigned char *data) override
   {
     ret->deserialize(data);
     waiting = false;
   }
-  virtual const char * getMsgType()
+  virtual const char * getMsgType() override
   {
     return this->resp.getType();
   }
-  virtual const char * getMsgMD5()
+  virtual const char * getMsgMD5() override
   {
     return this->resp.getMD5();
   }
-  virtual int getEndpointType()
+  virtual int getEndpointType() override
   {
     return rosserial_msgs::TopicInfo::ID_SERVICE_CLIENT + rosserial_msgs::TopicInfo::ID_SUBSCRIBER;
   }

--- a/rosserial_client/src/ros_lib/ros/service_server.h
+++ b/rosserial_client/src/ros_lib/ros/service_server.h
@@ -58,21 +58,21 @@ public:
   }
 
   // these refer to the subscriber
-  virtual void callback(unsigned char *data)
+  virtual void callback(unsigned char *data) override
   {
     req.deserialize(data);
     (obj_->*cb_)(req, resp);
     pub.publish(&resp);
   }
-  virtual const char * getMsgType()
+  virtual const char * getMsgType() override
   {
     return this->req.getType();
   }
-  virtual const char * getMsgMD5()
+  virtual const char * getMsgMD5() override
   {
     return this->req.getMD5();
   }
-  virtual int getEndpointType()
+  virtual int getEndpointType() override
   {
     return rosserial_msgs::TopicInfo::ID_SERVICE_SERVER + rosserial_msgs::TopicInfo::ID_SUBSCRIBER;
   }
@@ -99,21 +99,21 @@ public:
   }
 
   // these refer to the subscriber
-  virtual void callback(unsigned char *data)
+  virtual void callback(unsigned char *data) override
   {
     req.deserialize(data);
     cb_(req, resp);
     pub.publish(&resp);
   }
-  virtual const char * getMsgType()
+  virtual const char * getMsgType() override
   {
     return this->req.getType();
   }
-  virtual const char * getMsgMD5()
+  virtual const char * getMsgMD5() override
   {
     return this->req.getMD5();
   }
-  virtual int getEndpointType()
+  virtual int getEndpointType() override
   {
     return rosserial_msgs::TopicInfo::ID_SERVICE_SERVER + rosserial_msgs::TopicInfo::ID_SUBSCRIBER;
   }

--- a/rosserial_client/src/ros_lib/ros/subscriber.h
+++ b/rosserial_client/src/ros_lib/ros/subscriber.h
@@ -71,21 +71,21 @@ public:
     topic_ = topic_name;
   };
 
-  virtual void callback(unsigned char* data)
+  virtual void callback(unsigned char* data) override
   {
     msg.deserialize(data);
     (obj_->*cb_)(msg);
   }
 
-  virtual const char * getMsgType()
+  virtual const char * getMsgType() override
   {
     return this->msg.getType();
   }
-  virtual const char * getMsgMD5()
+  virtual const char * getMsgMD5() override
   {
     return this->msg.getMD5();
   }
-  virtual int getEndpointType()
+  virtual int getEndpointType() override
   {
     return endpoint_;
   }
@@ -111,21 +111,21 @@ public:
     topic_ = topic_name;
   };
 
-  virtual void callback(unsigned char* data)
+  virtual void callback(unsigned char* data) override
   {
     msg.deserialize(data);
     this->cb_(msg);
   }
 
-  virtual const char * getMsgType()
+  virtual const char * getMsgType() override
   {
     return this->msg.getType();
   }
-  virtual const char * getMsgMD5()
+  virtual const char * getMsgMD5() override
   {
     return this->msg.getMD5();
   }
-  virtual int getEndpointType()
+  virtual int getEndpointType() override
   {
     return endpoint_;
   }

--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -210,7 +210,7 @@ class ArrayDataType(PrimitiveDataType):
 
     def make_initializer(self, f, trailer):
         if self.size == None:
-            f.write('      %s_length(0), %s(NULL)%s\n' % (self.name, self.name, trailer))
+            f.write('      %s_length(0), st_%s(), %s(NULL)%s\n' % (self.name, self.name, self.name, trailer))
         else:
             f.write('      %s()%s\n' % (self.name, trailer))
 
@@ -343,7 +343,7 @@ class Message:
 
     def _write_serializer(self, f):
                 # serializer
-        f.write('    virtual int serialize(unsigned char *outbuffer) const\n')
+        f.write('    virtual int serialize(unsigned char *outbuffer) const override\n')
         f.write('    {\n')
         f.write('      int offset = 0;\n')
         for d in self.data:
@@ -354,7 +354,7 @@ class Message:
 
     def _write_deserializer(self, f):
         # deserializer
-        f.write('    virtual int deserialize(unsigned char *inbuffer)\n')
+        f.write('    virtual int deserialize(unsigned char *inbuffer) override\n')
         f.write('    {\n')
         f.write('      int offset = 0;\n')
         for d in self.data:
@@ -389,10 +389,10 @@ class Message:
         f.write('\n')
 
     def _write_getType(self, f):
-        f.write('    const char * getType(){ return "%s/%s"; };\n'%(self.package, self.name))
+        f.write('    virtual const char * getType() override { return "%s/%s"; };\n'%(self.package, self.name))
 
     def _write_getMD5(self, f):
-        f.write('    const char * getMD5(){ return "%s"; };\n'%self.md5)
+        f.write('    virtual const char * getMD5() override { return "%s"; };\n'%self.md5)
 
     def _write_impl(self, f):
         f.write('  class %s : public ros::Msg\n' % self.name)
@@ -465,7 +465,7 @@ class Service:
         f.write('static const char %s[] = "%s/%s";\n'%(self.name.upper(), self.package, self.name))
 
         def write_type(out, name):
-            out.write('    const char * getType(){ return %s; };\n'%(name))
+            out.write('    virtual const char * getType() override { return %s; };\n'%(name))
         _write_getType = lambda out: write_type(out, self.name.upper())
         self.req._write_getType = _write_getType
         self.resp._write_getType = _write_getType

--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -210,7 +210,7 @@ class ArrayDataType(PrimitiveDataType):
 
     def make_initializer(self, f, trailer):
         if self.size == None:
-            f.write('      %s_length(0), st_%s(), %s(NULL)%s\n' % (self.name, self.name, self.name, trailer))
+            f.write('      %s_length(0), st_%s(), %s(nullptr)%s\n' % (self.name, self.name, self.name, trailer))
         else:
             f.write('      %s()%s\n' % (self.name, trailer))
 

--- a/rosserial_python/nodes/serial_node.py
+++ b/rosserial_python/nodes/serial_node.py
@@ -44,7 +44,6 @@ import multiprocessing
 import sys
 
 if __name__=="__main__":
-
     rospy.init_node("serial_node")
     rospy.loginfo("ROS Serial Python Node")
 

--- a/rosserial_python/nodes/serial_node.py
+++ b/rosserial_python/nodes/serial_node.py
@@ -96,8 +96,7 @@ if __name__=="__main__":
                 sleep(1.0)
                 continue
             except:
-                rospy.logwarn("Unexpected Error.%s", sys.exc_info()[0])
+                rospy.logwarn("Unexpected Error: %s", sys.exc_info()[0])
                 client.port.close()
                 sleep(1.0)
                 continue
-

--- a/rosserial_python/package.xml
+++ b/rosserial_python/package.xml
@@ -15,5 +15,5 @@
   <run_depend>rospy</run_depend>
   <run_depend>rosserial_msgs</run_depend>
   <run_depend>diagnostic_msgs</run_depend>
-  <run_depend>python-serial</run_depend>
+  <run_depend>python3-serial</run_depend>
 </package>

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -287,12 +287,9 @@ class RosSerialServer:
 
         while totalsent < length:
             try:
-                sent = self.socket.send(data[totalsent:])
+                totalsent += self.socket.send(data[totalsent:])
             except BrokenPipeError:
-                sent = 0
-            if sent == 0:
                 raise RuntimeError("RosSerialServer.write() socket connection broken")
-            totalsent = totalsent + sent
 
     def read(self, rqsted_length):
         self.msg = b''

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -301,7 +301,7 @@ class RosSerialServer:
 
         while len(self.msg) < rqsted_length:
             chunk = self.socket.recv(rqsted_length - len(self.msg))
-            if chunk == '':
+            if chunk == b'':
                 raise RuntimeError("RosSerialServer.read() socket connection broken")
             self.msg = self.msg + chunk
         return self.msg
@@ -309,7 +309,7 @@ class RosSerialServer:
     def inWaiting(self):
         try: # the caller checks just for <1, so we'll peek at just one byte
             chunk = self.socket.recv(1, socket.MSG_DONTWAIT|socket.MSG_PEEK)
-            if chunk == '':
+            if chunk == b'':
                 raise RuntimeError("RosSerialServer.inWaiting() socket connection broken")
             return len(chunk)
         except BlockingIOError:
@@ -538,7 +538,7 @@ class SerialClient(object):
                 else:
                     rospy.loginfo("wrong checksum for topic id and msg")
 
-            except ImportError as exc:
+            except IOError as exc:
                 rospy.logwarn('Last read step: %s' % read_step)
                 rospy.logwarn('Run loop error: %s' % exc)
                 # One of the read calls had an issue. Just to be safe, request that the client

--- a/rosserial_python/src/rosserial_python/__init__.py
+++ b/rosserial_python/src/rosserial_python/__init__.py
@@ -1,1 +1,1 @@
-from SerialClient import *
+from .SerialClient import *

--- a/rosserial_test/CMakeLists.txt
+++ b/rosserial_test/CMakeLists.txt
@@ -21,7 +21,8 @@ if(CATKIN_ENABLE_TESTING)
   # Generate a client library for the test harnesses to use.
   add_custom_command(
     OUTPUT ${PROJECT_BINARY_DIR}/include/rosserial
-    COMMAND ${CATKIN_DEVEL_PREFIX}/env.sh rosrun ${PROJECT_NAME} generate_client_ros_lib ${PROJECT_BINARY_DIR}/include
+    COMMAND ${CATKIN_DEVEL_PREFIX}/env.sh ${PYTHON_EXECUTABLE}
+            ${PROJECT_SOURCE_DIR}/scripts/generate_client_ros_lib ${PROJECT_BINARY_DIR}/include
   )
   add_custom_target(${PROJECT_NAME}_rosserial_lib DEPENDS ${PROJECT_BINARY_DIR}/include/rosserial)
   add_dependencies(${PROJECT_NAME}_rosserial_lib ${catkin_EXPORTED_TARGETS})
@@ -47,7 +48,3 @@ if(CATKIN_ENABLE_TESTING)
   # Disabled due to reconnect logic in rosserial_python not being robust enough.
   # add_rostest(test/rosserial_python_serial.test)
 endif()
-
-catkin_install_python(PROGRAMS scripts/generate_client_ros_lib
-  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)

--- a/rosserial_test/scripts/generate_client_ros_lib
+++ b/rosserial_test/scripts/generate_client_ros_lib
@@ -35,12 +35,12 @@ ROS_TO_EMBEDDED_TYPES = {
 
 # need correct inputs
 if (len(sys.argv) < 2):
-    print __usage__
+    print(__usage__)
     exit()
 
 # output path
 path = path.join(sys.argv[1], 'rosserial')
-print "\nExporting to %s" % path
+print("\nExporting to %s" % path)
 
 rospack = rospkg.RosPack()
 rosserial_client_copy_files(rospack, path + sep)

--- a/rosserial_test/scripts/generate_client_ros_lib
+++ b/rosserial_test/scripts/generate_client_ros_lib
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 __usage__ = """
 make_libraries generates the rosserial library files.  It
 is passed the output folder. This version does not copy a ros.h,

--- a/rosserial_xbee/package.xml
+++ b/rosserial_xbee/package.xml
@@ -21,7 +21,7 @@
   <run_depend>rospy</run_depend>
   <run_depend>rosserial_msgs</run_depend>
   <run_depend>diagnostic_msgs</run_depend>
-  <run_depend>python-serial</run_depend>
+  <run_depend>python3-serial</run_depend>
   <run_depend>rosserial_python</run_depend>
 </package>
 


### PR DESCRIPTION
A bunch of stuff that came up when testing with the GCC9-based toolchain that will ship in Ubuntu Focal:
- Add missing member initializations.
- Add missing override specifiers.
- Hacky cast for the 16 bit AVR float logic.

There are a few more member initializations to add in NodeHandle. Will get to those before merging.

Also, I believe this will break Bionic, and it's a pretty breaking change regardless, so this probably merits cutting a `noetic-devel` branch for it.