### PR TITLE
Do not fail when trying to update ros_lib which already exists

### DIFF
--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -572,10 +572,10 @@ def rosserial_generate(rospack, path, mapping):
     print('\n')
 
 def rosserial_client_copy_files(rospack, path):
-    if not os.path.exists(path+"/ros"):
-        os.makedirs(path+"/ros")
-    if not os.path.exists(path+"/tf"):
-        os.makedirs(path+"/tf")
+    if not os.path.exists(path + "/ros"):
+        os.makedirs(path + "/ros")
+    if not os.path.exists(path + "/tf"):
+        os.makedirs(path + "/tf")
     files = ['duration.cpp',
              'time.cpp',
              'ros/duration.h',

--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -572,8 +572,10 @@ def rosserial_generate(rospack, path, mapping):
     print('\n')
 
 def rosserial_client_copy_files(rospack, path):
-    os.makedirs(path+"/ros")
-    os.makedirs(path+"/tf")
+    if not os.path.exists(path+"/ros"):
+        os.makedirs(path+"/ros")
+    if not os.path.exists(path+"/tf"):
+        os.makedirs(path+"/tf")
     files = ['duration.cpp',
              'time.cpp',
              'ros/duration.h',


### PR DESCRIPTION
When running `rosrun rosserial_client make_libraries` somewhere where the `ros_lib` directory already exists (for updating message definitions), the script terminates with an error message.

I decided to add these checks in the same way as in line 546, for the sake of consistency. (Python 3.2 and later allow an additional parameter `exist_ok` for this, but that could not be backported to Melodic.)