### PR TITLE
Fix/time

### DIFF
--- a/rosserial_client/CMakeLists.txt
+++ b/rosserial_client/CMakeLists.txt
@@ -8,12 +8,15 @@ catkin_package(
 
 catkin_python_setup()
 
+add_library(${PROJECT_NAME} src/ros_lib/duration.cpp src/ros_lib/time.cpp)
+
 if(CATKIN_ENABLE_TESTING)
   find_package(rosserial_msgs REQUIRED)
   include_directories(src ${rosserial_msgs_INCLUDE_DIRS})
   catkin_add_gtest(float64_test test/float64_test.cpp)
   catkin_add_gtest(subscriber_test test/subscriber_test.cpp)
   catkin_add_gtest(time_test test/time_test.cpp)
+  target_link_libraries(time_test ${PROJECT_NAME})
 endif()
 
 install(

--- a/rosserial_client/CMakeLists.txt
+++ b/rosserial_client/CMakeLists.txt
@@ -8,15 +8,12 @@ catkin_package(
 
 catkin_python_setup()
 
-add_library(${PROJECT_NAME} src/ros_lib/duration.cpp src/ros_lib/time.cpp)
-
 if(CATKIN_ENABLE_TESTING)
   find_package(rosserial_msgs REQUIRED)
   include_directories(src/ros_lib ${rosserial_msgs_INCLUDE_DIRS})
   catkin_add_gtest(float64_test test/float64_test.cpp)
   catkin_add_gtest(subscriber_test test/subscriber_test.cpp)
-  catkin_add_gtest(time_test test/time_test.cpp)
-  target_link_libraries(time_test ${PROJECT_NAME})
+  catkin_add_gtest(time_test test/time_test.cpp src/ros_lib/duration.cpp src/ros_lib/time.cpp)
 endif()
 
 install(

--- a/rosserial_client/CMakeLists.txt
+++ b/rosserial_client/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(${PROJECT_NAME} src/ros_lib/duration.cpp src/ros_lib/time.cpp)
 
 if(CATKIN_ENABLE_TESTING)
   find_package(rosserial_msgs REQUIRED)
-  include_directories(src ${rosserial_msgs_INCLUDE_DIRS})
+  include_directories(src/ros_lib ${rosserial_msgs_INCLUDE_DIRS})
   catkin_add_gtest(float64_test test/float64_test.cpp)
   catkin_add_gtest(subscriber_test test/subscriber_test.cpp)
   catkin_add_gtest(time_test test/time_test.cpp)

--- a/rosserial_client/CMakeLists.txt
+++ b/rosserial_client/CMakeLists.txt
@@ -13,6 +13,7 @@ if(CATKIN_ENABLE_TESTING)
   include_directories(src ${rosserial_msgs_INCLUDE_DIRS})
   catkin_add_gtest(float64_test test/float64_test.cpp)
   catkin_add_gtest(subscriber_test test/subscriber_test.cpp)
+  catkin_add_gtest(time_test test/time_test.cpp)
 endif()
 
 install(

--- a/rosserial_client/src/ros_lib/ros/time.h
+++ b/rosserial_client/src/ros_lib/ros/time.h
@@ -35,7 +35,7 @@
 #ifndef ROS_TIME_H_
 #define ROS_TIME_H_
 
-#include "ros/duration.h"
+#include "duration.h"
 #include <math.h>
 #include <stdint.h>
 

--- a/rosserial_client/src/ros_lib/ros/time.h
+++ b/rosserial_client/src/ros_lib/ros/time.h
@@ -35,7 +35,7 @@
 #ifndef ROS_TIME_H_
 #define ROS_TIME_H_
 
-#include "duration.h"
+#include "ros/duration.h"
 #include <math.h>
 #include <stdint.h>
 

--- a/rosserial_client/src/ros_lib/time.cpp
+++ b/rosserial_client/src/ros_lib/time.cpp
@@ -54,16 +54,15 @@ Time& Time::fromNSec(int32_t t)
 
 Time& Time::operator +=(const Duration &rhs)
 {
-  sec += rhs.sec;
-  nsec += rhs.nsec;
+  sec = sec - 1 + rhs.sec;
+  nsec += 1000000000L + rhs.nsec;
   normalizeSecNSec(sec, nsec);
   return *this;
 }
 
-Time& Time::operator -=(const Duration &rhs)
-{
-  sec += -rhs.sec;
-  nsec += -rhs.nsec;
+Time& Time::operator -=(const Duration &rhs){
+  sec = sec - 1 - rhs.sec;
+  nsec += 1000000000L - rhs.nsec;
   normalizeSecNSec(sec, nsec);
   return *this;
 }

--- a/rosserial_client/src/ros_lib/time.cpp
+++ b/rosserial_client/src/ros_lib/time.cpp
@@ -55,14 +55,14 @@ Time& Time::fromNSec(int32_t t)
 Time& Time::operator +=(const Duration &rhs)
 {
   sec = sec - 1 + rhs.sec;
-  nsec += 1000000000UL + rhs.nsec;
+  nsec = nsec + 1000000000UL + rhs.nsec;
   normalizeSecNSec(sec, nsec);
   return *this;
 }
 
 Time& Time::operator -=(const Duration &rhs){
   sec = sec - 1 - rhs.sec;
-  nsec += 1000000000UL - rhs.nsec;
+  nsec = nsec + 1000000000UL - rhs.nsec;
   normalizeSecNSec(sec, nsec);
   return *this;
 }

--- a/rosserial_client/src/ros_lib/time.cpp
+++ b/rosserial_client/src/ros_lib/time.cpp
@@ -55,14 +55,14 @@ Time& Time::fromNSec(int32_t t)
 Time& Time::operator +=(const Duration &rhs)
 {
   sec = sec - 1 + rhs.sec;
-  nsec += 1000000000L + rhs.nsec;
+  nsec += 1000000000UL + rhs.nsec;
   normalizeSecNSec(sec, nsec);
   return *this;
 }
 
 Time& Time::operator -=(const Duration &rhs){
   sec = sec - 1 - rhs.sec;
-  nsec += 1000000000L - rhs.nsec;
+  nsec += 1000000000UL - rhs.nsec;
   normalizeSecNSec(sec, nsec);
   return *this;
 }

--- a/rosserial_client/test/float64_test.cpp
+++ b/rosserial_client/test/float64_test.cpp
@@ -1,4 +1,4 @@
-#include "ros_lib/ros/msg.h"
+#include "ros/msg.h"
 #include <gtest/gtest.h>
 #include <math.h>
 

--- a/rosserial_client/test/subscriber_test.cpp
+++ b/rosserial_client/test/subscriber_test.cpp
@@ -1,4 +1,4 @@
-#include "ros_lib/ros/subscriber.h"
+#include "ros/subscriber.h"
 #include <gtest/gtest.h>
 
 

--- a/rosserial_client/test/time_test.cpp
+++ b/rosserial_client/test/time_test.cpp
@@ -15,7 +15,7 @@ public:
 };
 
 const ros::Time TestTime::times[] = {
-    {0L, 0L}, {0L, 500000000L}, {1L, 500000000L}};
+    {0UL, 0UL}, {0UL, 500000000UL}, {1UL, 500000000UL}};
 
 const ros::Duration TestTime::durations[] = {
     {0L, 0L}, {0L, 500000000L}, {0L, 600000000L}, {1L, 600000000L}};
@@ -25,22 +25,23 @@ const int TestTime::num_durations =
     sizeof(TestTime::durations) / sizeof(ros::Duration);
 
 const ros::Time TestTime::additions[] = {
-    {0L, 0L},         {0L, 500000000L}, {0L, 600000000L}, {1L, 600000000L},
-    {0L, 500000000L}, {1L, 0L},         {1L, 100000000L}, {2L, 100000000L},
-    {1L, 500000000L}, {2L, 0L},         {2L, 100000000L}, {3L, 100000000L}};
+    {0UL, 0UL},        {0UL, 500000000UL}, {0L, 600000000UL},
+    {1L, 600000000UL}, {0UL, 500000000UL}, {1UL, 0UL},
+    {1L, 100000000UL}, {2L, 100000000UL},  {1UL, 500000000UL},
+    {2UL, 0UL},        {2L, 100000000UL},  {3L, 100000000UL}};
 
 const ros::Time TestTime::subtractions[] = {{0L, 0L},
-                                            {0xFFFFFFFF, 500000000L},
-                                            {0xFFFFFFFF, 400000000L},
-                                            {0xFFFFFFFF - 1, 400000000L},
-                                            {0L, 500000000L},
-                                            {0L, 0L},
-                                            {0xFFFFFFFF, 900000000L},
-                                            {0xFFFFFFFF - 1, 900000000L},
-                                            {1L, 500000000L},
-                                            {1L, 0L},
-                                            {0L, 900000000L},
-                                            {0xFFFFFFFF, 900000000L}};
+                                            {0xFFFFFFFF, 500000000UL},
+                                            {0xFFFFFFFF, 400000000UL},
+                                            {0xFFFFFFFF - 1, 400000000UL},
+                                            {0UL, 500000000UL},
+                                            {0UL, 0UL},
+                                            {0xFFFFFFFF, 900000000UL},
+                                            {0xFFFFFFFF - 1, 900000000UL},
+                                            {1UL, 500000000UL},
+                                            {1UL, 0UL},
+                                            {0UL, 900000000UL},
+                                            {0xFFFFFFFF, 900000000UL}};
 
 TEST_F(TestTime, testAddition) {
   for (int i = 0; i < num_times; ++i) {
@@ -48,8 +49,12 @@ TEST_F(TestTime, testAddition) {
       auto time = times[i];
       time += durations[j];
       auto idx = i * num_durations + j;
-      EXPECT_EQ(time.sec, additions[idx].sec);
-      EXPECT_EQ(time.nsec, additions[idx].nsec);
+      EXPECT_EQ(time.sec, additions[idx].sec)
+          << "Add " << durations[j].sec << "." << durations[j].nsec << " to "
+          << times[i].sec << "." << times[i].nsec;
+      EXPECT_EQ(time.nsec, additions[idx].nsec)
+          << "Add " << durations[j].sec << "." << durations[j].nsec << " to "
+          << times[i].sec << "." << times[i].nsec;
     }
   }
 }
@@ -60,8 +65,12 @@ TEST_F(TestTime, testSubtraction) {
       auto time = times[i];
       time -= durations[j];
       auto idx = i * num_durations + j;
-      EXPECT_EQ(time.sec, additions[idx].sec);
-      EXPECT_EQ(time.nsec, additions[idx].nsec);
+      EXPECT_EQ(time.sec, subtractions[idx].sec)
+          << "Subtract " << durations[j].sec << "." << durations[j].nsec
+          << " from " << times[i].sec << "." << times[i].nsec;
+      EXPECT_EQ(time.nsec, subtractions[idx].nsec)
+          << "Subtract " << durations[j].sec << "." << durations[j].nsec
+          << " from " << times[i].sec << "." << times[i].nsec;
     }
   }
 }

--- a/rosserial_client/test/time_test.cpp
+++ b/rosserial_client/test/time_test.cpp
@@ -1,5 +1,5 @@
-#include "ros_lib/ros/duration.h"
-#include "ros_lib/ros/time.h"
+#include "ros/duration.h"
+#include "ros/time.h"
 #include <gtest/gtest.h>
 
 class TestTime : public ::testing::Test {

--- a/rosserial_client/test/time_test.cpp
+++ b/rosserial_client/test/time_test.cpp
@@ -1,0 +1,72 @@
+#include "ros_lib/ros/duration.h"
+#include "ros_lib/ros/time.h"
+#include <gtest/gtest.h>
+
+class TestTime : public ::testing::Test {
+public:
+  static const ros::Time times[];
+  static const ros::Duration durations[];
+  static const int num_times;
+  static const int num_durations;
+
+  static const ros::Time additions[];
+
+  static const ros::Time subtractions[];
+};
+
+const ros::Time TestTime::times[] = {
+    {0L, 0L}, {0L, 500000000L}, {1L, 500000000L}};
+
+const ros::Duration TestTime::durations[] = {
+    {0L, 0L}, {0L, 500000000L}, {0L, 600000000L}, {1L, 600000000L}};
+
+const int TestTime::num_times = sizeof(TestTime::times) / sizeof(ros::Time);
+const int TestTime::num_durations =
+    sizeof(TestTime::durations) / sizeof(ros::Duration);
+
+const ros::Time TestTime::additions[] = {
+    {0L, 0L},         {0L, 500000000L}, {0L, 600000000L}, {1L, 600000000L},
+    {0L, 500000000L}, {1L, 0L},         {1L, 100000000L}, {2L, 100000000L},
+    {1L, 500000000L}, {2L, 0L},         {2L, 100000000L}, {3L, 100000000L}};
+
+const ros::Time TestTime::subtractions[] = {{0L, 0L},
+                                            {0xFFFFFFFF, 500000000L},
+                                            {0xFFFFFFFF, 400000000L},
+                                            {0xFFFFFFFF - 1, 400000000L},
+                                            {0L, 500000000L},
+                                            {0L, 0L},
+                                            {0xFFFFFFFF, 900000000L},
+                                            {0xFFFFFFFF - 1, 900000000L},
+                                            {1L, 500000000L},
+                                            {1L, 0L},
+                                            {0L, 900000000L},
+                                            {0xFFFFFFFF, 900000000L}};
+
+TEST_F(TestTime, testAddition) {
+  for (int i = 0; i < num_times; ++i) {
+    for (int j = 0; j < num_durations; ++j) {
+      auto time = times[i];
+      time += durations[j];
+      auto idx = i * num_durations + j;
+      EXPECT_EQ(time.sec, additions[idx].sec);
+      EXPECT_EQ(time.nsec, additions[idx].nsec);
+    }
+  }
+}
+
+TEST_F(TestTime, testSubtraction) {
+  for (int i = 0; i < num_times; ++i) {
+    for (int j = 0; j < num_durations; ++j) {
+      auto time = times[i];
+      time -= durations[j];
+      auto idx = i * num_durations + j;
+      EXPECT_EQ(time.sec, additions[idx].sec);
+      EXPECT_EQ(time.nsec, additions[idx].nsec);
+    }
+  }
+}
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
In https://github.com/ros-drivers/rosserial/issues/169 @PaulBouchier mentions that the implementation of subtraction and addition of time and duration may be erroneous. We actually observed that 
```
ros::Time time = {1, 0};
time -= ros::Duration(0, 1000000);
```
indeed lead to a wrong result on our system.

This PR implements the fix provided by @chuck-h and additional unit tests. 

~~Since I cannot run the unit tests on my machine I'm creating this draft PR first.~~