### PR TITLE
Method to compute duration between time stamps

### DIFF
--- a/rosserial_client/src/ros_lib/ros/time.h
+++ b/rosserial_client/src/ros_lib/ros/time.h
@@ -72,6 +72,7 @@ public:
 
   Time& operator +=(const Duration &rhs);
   Time& operator -=(const Duration &rhs);
+  Duration operator -(const Time &rhs) const;
 
   static Time now();
   static void setNow(Time & new_now);

--- a/rosserial_client/src/ros_lib/ros/time.h
+++ b/rosserial_client/src/ros_lib/ros/time.h
@@ -35,7 +35,7 @@
 #ifndef ROS_TIME_H_
 #define ROS_TIME_H_
 
-#include "ros/duration.h"
+#include "duration.h"
 #include <math.h>
 #include <stdint.h>
 

--- a/rosserial_client/src/ros_lib/ros/time.h
+++ b/rosserial_client/src/ros_lib/ros/time.h
@@ -35,7 +35,7 @@
 #ifndef ROS_TIME_H_
 #define ROS_TIME_H_
 
-#include "duration.h"
+#include "ros/duration.h"
 #include <math.h>
 #include <stdint.h>
 

--- a/rosserial_client/src/ros_lib/time.cpp
+++ b/rosserial_client/src/ros_lib/time.cpp
@@ -66,4 +66,13 @@ Time& Time::operator -=(const Duration &rhs){
   normalizeSecNSec(sec, nsec);
   return *this;
 }
+
+Duration Time::operator-(const Time &rhs) const {
+  // Note: Considers wrap around as a continuation of time, e.g.,
+  // (0,0) - (0xFFFFFFFF, 0) = (1, 0)
+  Duration d;
+  d.sec = sec > rhs.sec ? sec - rhs.sec : -(rhs.sec - sec);
+  d.nsec = nsec > rhs.nsec ? nsec - rhs.nsec : -(rhs.nsec - nsec);
+  normalizeSecNSecSigned(d.sec, d.nsec);
+  return d;
 }

--- a/rosserial_client/src/ros_lib/time.cpp
+++ b/rosserial_client/src/ros_lib/time.cpp
@@ -76,3 +76,4 @@ Duration Time::operator-(const Time &rhs) const {
   normalizeSecNSecSigned(d.sec, d.nsec);
   return d;
 }
+}

--- a/rosserial_client/test/time_test.cpp
+++ b/rosserial_client/test/time_test.cpp
@@ -10,7 +10,6 @@ public:
   static const int num_durations;
 
   static const ros::Time additions[];
-
   static const ros::Time subtractions[];
 };
 
@@ -18,30 +17,54 @@ const ros::Time TestTime::times[] = {
     {0UL, 0UL}, {0UL, 500000000UL}, {1UL, 500000000UL}};
 
 const ros::Duration TestTime::durations[] = {
-    {0L, 0L}, {0L, 500000000L}, {0L, 600000000L}, {1L, 600000000L}};
+    {0L, 0L},         {0L, 500000000L},  {0L, 600000000L},
+    {1L, 600000000L}, {0L, -100000000L}, {-1L, 100000000L}};
 
 const int TestTime::num_times = sizeof(TestTime::times) / sizeof(ros::Time);
 const int TestTime::num_durations =
     sizeof(TestTime::durations) / sizeof(ros::Duration);
 
-const ros::Time TestTime::additions[] = {
-    {0UL, 0UL},        {0UL, 500000000UL}, {0L, 600000000UL},
-    {1L, 600000000UL}, {0UL, 500000000UL}, {1UL, 0UL},
-    {1L, 100000000UL}, {2L, 100000000UL},  {1UL, 500000000UL},
-    {2UL, 0UL},        {2L, 100000000UL},  {3L, 100000000UL}};
+const ros::Time TestTime::additions[] = {{0UL, 0UL},
+                                         {0UL, 500000000UL},
+                                         {0UL, 600000000UL},
+                                         {1UL, 600000000UL},
+                                         {0xFFFFFFFF, 900000000UL},
+                                         {0xFFFFFFFF, 100000000UL},
+
+                                         {0UL, 500000000UL},
+                                         {1UL, 0UL},
+                                         {1UL, 100000000UL},
+                                         {2UL, 100000000UL},
+                                         {0UL, 400000000UL},
+                                         {0xFFFFFFFF, 600000000UL},
+
+                                         {1UL, 500000000UL},
+                                         {2UL, 0UL},
+                                         {2UL, 100000000UL},
+                                         {3UL, 100000000UL},
+                                         {1UL, 400000000UL},
+                                         {0UL, 600000000UL}};
 
 const ros::Time TestTime::subtractions[] = {{0L, 0L},
                                             {0xFFFFFFFF, 500000000UL},
                                             {0xFFFFFFFF, 400000000UL},
                                             {0xFFFFFFFF - 1, 400000000UL},
+                                            {0UL, 100000000UL},
+                                            {0UL, 900000000UL},
+
                                             {0UL, 500000000UL},
                                             {0UL, 0UL},
                                             {0xFFFFFFFF, 900000000UL},
                                             {0xFFFFFFFF - 1, 900000000UL},
+                                            {0UL, 600000000UL},
+                                            {1UL, 400000000UL},
+
                                             {1UL, 500000000UL},
                                             {1UL, 0UL},
                                             {0UL, 900000000UL},
-                                            {0xFFFFFFFF, 900000000UL}};
+                                            {0xFFFFFFFF, 900000000UL},
+                                            {1UL, 600000000UL},
+                                            {2UL, 400000000UL}};
 
 TEST_F(TestTime, testAddition) {
   for (int i = 0; i < num_times; ++i) {
@@ -55,6 +78,14 @@ TEST_F(TestTime, testAddition) {
       EXPECT_EQ(time.nsec, additions[idx].nsec)
           << "Add " << durations[j].sec << "." << durations[j].nsec << " to "
           << times[i].sec << "." << times[i].nsec;
+
+      auto dur = time - times[i];
+      EXPECT_EQ(dur.sec, durations[j].sec)
+          << "Subtract " << times[i].sec << "." << times[i].nsec << " from "
+          << time.sec << "." << time.nsec;
+      EXPECT_EQ(dur.nsec, durations[j].nsec)
+          << "Subtract " << times[i].sec << "." << times[i].nsec << " from "
+          << time.sec << "." << time.nsec;
     }
   }
 }
@@ -71,6 +102,14 @@ TEST_F(TestTime, testSubtraction) {
       EXPECT_EQ(time.nsec, subtractions[idx].nsec)
           << "Subtract " << durations[j].sec << "." << durations[j].nsec
           << " from " << times[i].sec << "." << times[i].nsec;
+
+      auto dur = times[i] - time;
+      EXPECT_EQ(dur.sec, durations[j].sec)
+          << "Subtract " << time.sec << "." << time.nsec << " from "
+          << times[i].sec << "." << times[i].nsec;
+      EXPECT_EQ(dur.nsec, durations[j].nsec)
+          << "Subtract " << time.sec << "." << time.nsec << " from "
+          << times[i].sec << "." << times[i].nsec;
     }
   }
 }


### PR DESCRIPTION
This PR adds a method to compute the difference between two time stamps `Duration operator -(const Time &rhs)`.

We use this for example to compute the duration between two strobe signals of a camera or to compute durations between reading sensor signals.