### PR TITLE
output_path missing "/" for "copy ros_lib stuff"

### DIFF
--- a/rosserial_arduino/src/rosserial_arduino/make_libraries.py
+++ b/rosserial_arduino/src/rosserial_arduino/make_libraries.py
@@ -77,7 +77,7 @@ if (len(sys.argv) < 2):
 
 # get output path
 path = sys.argv[1]
-output_path = os.path.join(sys.argv[1], "ros_lib")
+output_path = os.path.join(sys.argv[1], "ros_lib/")
 print("\nExporting to %s" % output_path)
 
 rospack = rospkg.RosPack()


### PR DESCRIPTION
Not exactly sure what happened in https://github.com/ros-drivers/rosserial/pull/495/commits/c7cd984e1dc53e64b7f9323c09a1a7c7c2c09416 but I needed to add a "/" to line-80 "output_path = os.path.join(sys.argv[1], "ros_lib/")" so make_libraries.py will copy and find files in to the Arduino/libraries/ros_lib directory.