### PR TITLE
Fixing message size issue.

### DIFF
--- a/rosserial_server/include/rosserial_server/session.h
+++ b/rosserial_server/include/rosserial_server/session.h
@@ -241,7 +241,9 @@ private:
     } else {
       if (callbacks_.count(topic_id) == 1) {
         try {
-          callbacks_[topic_id](stream);
+          // stream includes the check sum byte. 
+          ros::serialization::IStream msg_stream(stream.getData(), stream.getLength()-1);
+          callbacks_[topic_id](msg_stream);
         } catch(ros::serialization::StreamOverrunException e) {
           if (topic_id < 100) {
             ROS_ERROR("Buffer overrun when attempting to parse setup message.");


### PR DESCRIPTION
In rosserial_server the message is published with the rosserial checksum byte.
This means that subscribers receive an extra byte in each message.
Some clients (like [PlotJuggler)](https://github.com/facontidavide/PlotJuggler) consider the size mismatch an error. 