### PR TITLE
Remove "override" mark form "ServiceClient::call()" function

### DIFF
--- a/rosserial_client/src/ros_lib/ros/service_client.h
+++ b/rosserial_client/src/ros_lib/ros/service_client.h
@@ -54,7 +54,7 @@ public:
     this->waiting = true;
   }
 
-  virtual void call(const MReq & request, MRes & response) override
+  virtual void call(const MReq & request, MRes & response)
   {
     if (!pub.nh_->connected()) return;
     ret = &response;

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -269,7 +269,8 @@ class RosSerialServer:
             for sub in client.subscribers.values():
                 sub.unregister()
             for srv in client.services.values():
-                srv.unregister()
+                if isinstance(srv, ServiceServer):
+                    srv.unregister()
 
     def startSocketServer(self, port, address):
         rospy.loginfo("starting ROS Serial Python Node serial_node-%r" % address)


### PR DESCRIPTION
`ServiceClient::call ()` does not have a virtual function in ` Subscriber_`, so remove the `override` mark.