### PR TITLE
Changed C++ std::memcpy() into C version

### DIFF
--- a/rosserial_client/src/ros_lib/ros/msg.h
+++ b/rosserial_client/src/ros_lib/ros/msg.h
@@ -37,7 +37,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
-#include <cstring>
+#include <string.h>
 
 namespace ros
 {
@@ -65,7 +65,7 @@ public:
   static int serializeAvrFloat64(unsigned char* outbuffer, const float f)
   {
     int32_t val;
-    std::memcpy(&val, &f, sizeof(val));
+    memcpy(&val, &f, sizeof(val));
 
     int16_t exp = ((val >> 23) & 255);
     uint32_t mantissa = val & 0x7FFFFF;
@@ -179,7 +179,7 @@ public:
     // Copy negative sign.
     val |= (static_cast<uint32_t>(*(inbuffer++)) & 0x80) << 24;
 
-    std::memcpy(f, &val, sizeof(val));
+    memcpy(f, &val, sizeof(val));
     return 8;
   }
 


### PR DESCRIPTION
The `cstring` include and `std::memcpy` code were causing issues with rosserial_arduino #518 . Arduino by default does not have the C++ standard library available, and "ros/msg.h" is copied by rosserial_arduino's "make_libraries.py" into the generated ros_lib Arduino library. The fix was simply to replace `memcpy` by its equivalent C version.