### PR TITLE
Use shutil.copyfile() instead of shutil.copy()

### DIFF
--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -590,5 +590,5 @@ def rosserial_client_copy_files(rospack, path):
              os.path.join('tf', 'transform_broadcaster.h')]
     mydir = rospack.get_path("rosserial_client")
     for f in files:
-        shutil.copy(os.path.join(mydir, "src", "ros_lib", f), os.path.join(path, f))
+        shutil.copyfile(os.path.join(mydir, "src", "ros_lib", f), os.path.join(path, f))
 


### PR DESCRIPTION
On my distribution, rosserial's files are installed readonly, and `shutil.copy()` preserves this when copying them. The causes `make_libraries` to fail the next time it runs as it tries to overwrite the readonly files. `shutil.copyfile()` does not preserve the permissions, preventing this problem.