### PR TITLE
Add separate namespace for log messages from clients (#2)

### DIFF
--- a/rosserial_server/include/rosserial_server/session.h
+++ b/rosserial_server/include/rosserial_server/session.h
@@ -476,11 +476,11 @@ private:
   void handle_log(ros::serialization::IStream& stream) {
     rosserial_msgs::Log l;
     ros::serialization::Serializer<rosserial_msgs::Log>::read(stream, l);
-    if(l.level == rosserial_msgs::Log::ROSDEBUG) ROS_DEBUG("%s", l.msg.c_str());
-    else if(l.level == rosserial_msgs::Log::INFO) ROS_INFO("%s", l.msg.c_str());
-    else if(l.level == rosserial_msgs::Log::WARN) ROS_WARN("%s", l.msg.c_str());
-    else if(l.level == rosserial_msgs::Log::ERROR) ROS_ERROR("%s", l.msg.c_str());
-    else if(l.level == rosserial_msgs::Log::FATAL) ROS_FATAL("%s", l.msg.c_str());
+    if(l.level == rosserial_msgs::Log::ROSDEBUG) ROS_DEBUG_NAMED("clients", "%s", l.msg.c_str());
+    else if(l.level == rosserial_msgs::Log::INFO) ROS_INFO_NAMED("clients", "%s", l.msg.c_str());
+    else if(l.level == rosserial_msgs::Log::WARN) ROS_WARN_NAMED("clients", "%s", l.msg.c_str());
+    else if(l.level == rosserial_msgs::Log::ERROR) ROS_ERROR_NAMED("clients", "%s", l.msg.c_str());
+    else if(l.level == rosserial_msgs::Log::FATAL) ROS_FATAL_NAMED("clients", "%s", l.msg.c_str());
   }
 
   void handle_time(ros::serialization::IStream& stream) {


### PR DESCRIPTION
I was curious what you all thought about adding a separate namespace for the log messages coming from clients? For my own project, I want to be able to set the logger level specifically for the client without confusing it with the other log messages coming from rosserial_server.

It doesn't look like there is a simple way to attach a client-specific name for this named logger, so this just adds one namespace for all clients.

Signed-off-by: Stephen Brawner <brawner@gmail.com>