### PR TITLE
Add python3-dev as build depend

### DIFF
--- a/rosserial_server/package.xml
+++ b/rosserial_server/package.xml
@@ -17,6 +17,7 @@
   <depend>std_msgs</depend>
   <depend>roscpp</depend>
   <depend>topic_tools</depend>
+  <build_depend>python3-dev</build_depend>
   <build_depend>libboost-thread-dev</build_depend>
   <exec_depend>libboost-thread</exec_depend>
 </package>


### PR DESCRIPTION
Fix #541

Without this fix PythonLibs (`find_package(PythonLibs REQUIRED)`) is not found. Fix verified locally using a prerelease_job.