### PR TITLE
rosserial_windows service client has some problem?

### DIFF
--- a/rosserial_arduino/src/ros_lib/ArduinoHardware.h
+++ b/rosserial_arduino/src/ros_lib/ArduinoHardware.h
@@ -70,7 +70,9 @@ class ArduinoHardware {
     }
     ArduinoHardware()
     {
-#if defined(USBCON) and !(defined(USE_USBCON))
+#if defined(_SAMD21_) and defined(USE_USBCON)
+      iostream=&SerialUSB;
+#elif defined(USBCON) and !(defined(USE_USBCON))
       /* Leonardo support */
       iostream = &Serial1;
 #elif defined(USE_TEENSY_HW_SERIAL) or defined(USE_STM32_HW_SERIAL)

--- a/rosserial_arduino/src/ros_lib/ros.h
+++ b/rosserial_arduino/src/ros_lib/ros.h
@@ -37,7 +37,7 @@
 
 #include "ros/node_handle.h"
 
-#if defined(ESP8266) or defined(ESP32) or defined(ROSSERIAL_ARDUINO_TCP)
+#if (defined(ESP8266) or defined(ESP32) or defined(ROSSERIAL_ARDUINO_TCP)) and not defined(ESP_SERIAL)
   #include "ArduinoTcpHardware.h"
 #else
   #include "ArduinoHardware.h"

--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -428,14 +428,13 @@ public:
   }
 
   /* Register a new subscriber */
-  template<typename SubscriberT>
-  bool subscribe(SubscriberT& s)
+  bool subscribe(Subscriber_& s)
   {
     for (int i = 0; i < MAX_SUBSCRIBERS; i++)
     {
       if (subscribers[i] == 0) // empty slot
       {
-        subscribers[i] = static_cast<Subscriber_*>(&s);
+        subscribers[i] = &s;
         s.id_ = i + 100;
         return true;
       }
@@ -448,16 +447,8 @@ public:
   bool advertiseService(ServiceServer<MReq, MRes, ObjT>& srv)
   {
     bool v = advertise(srv.pub);
-    for (int i = 0; i < MAX_SUBSCRIBERS; i++)
-    {
-      if (subscribers[i] == 0) // empty slot
-      {
-        subscribers[i] = static_cast<Subscriber_*>(&srv);
-        srv.id_ = i + 100;
-        return v;
-      }
-    }
-    return false;
+    bool w = subscribe(srv);
+    return v && w;
   }
 
   /* Register a new Service Client */
@@ -465,16 +456,8 @@ public:
   bool serviceClient(ServiceClient<MReq, MRes>& srv)
   {
     bool v = advertise(srv.pub);
-    for (int i = 0; i < MAX_SUBSCRIBERS; i++)
-    {
-      if (subscribers[i] == 0) // empty slot
-      {
-        subscribers[i] = static_cast<Subscriber_*>(&srv);
-        srv.id_ = i + 100;
-        return v;
-      }
-    }
-    return false;
+    bool w = subscribe(srv);
+    return v && w;
   }
 
   void negotiateTopics()

--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -572,8 +572,10 @@ def rosserial_generate(rospack, path, mapping):
     print('\n')
 
 def rosserial_client_copy_files(rospack, path):
-    os.makedirs(path+"/ros")
-    os.makedirs(path+"/tf")
+    if not os.path.exists(path + "/ros"):
+        os.makedirs(path + "/ros")
+    if not os.path.exists(path + "/tf"):
+        os.makedirs(path + "/tf")
     files = ['duration.cpp',
              'time.cpp',
              'ros/duration.h',

--- a/rosserial_server/src/msg_lookup.cpp
+++ b/rosserial_server/src/msg_lookup.cpp
@@ -73,14 +73,27 @@ const MsgInfo lookupMessage(const std::string& message_type, const std::string s
   Py_XDECREF(msg_class);
 
 #if PY_VERSION_HEX > 0x03000000
-  full_text = full_text ? full_text : PyUnicode_New(0, 0);
-  msginfo.full_text.assign(PyUnicode_AsUTF8(full_text));
+  if (full_text)
+  {
+    msginfo.full_text.assign(PyUnicode_AsUTF8(full_text));
+  }
   msginfo.md5sum.assign(PyUnicode_AsUTF8(md5sum));
 #else
-  full_text = full_text ? full_text : PyString_FromString("");
-  msginfo.full_text.assign(PyString_AsString(full_text));
+  if (full_text)
+  {
+    msginfo.full_text.assign(PyString_AsString(full_text));
+  }
   msginfo.md5sum.assign(PyString_AsString(md5sum));
 #endif
+
+  // See https://github.com/ros/ros_comm/issues/344
+  // and https://github.com/ros/gencpp/pull/14
+  // Valid full_text returned, but it is empty, so insert single line
+  if (full_text && msginfo.full_text.empty())
+  {
+    msginfo.full_text = "\n";
+  }
+
   Py_XDECREF(full_text);
   Py_XDECREF(md5sum);
   Py_Finalize();


### PR DESCRIPTION
It seems that  client.call have some problem
```
 roscpp_tutorials::TwoInts::Request req;
  roscpp_tutorials::TwoInts::Response res;
  ros::ServiceClient <roscpp_tutorials::TwoInts::Request, roscpp_tutorials::TwoInts::Response>
      client("/add_two_ints");
  req.a = int64_t(3);
  req.b = int64_t(4);
  nh.serviceClient(client);
  client.call(req, res);
```
I found it didn't work.
In service_client, the pub.nh_->connected() is false.
```
  virtual void call(const MReq & request, MRes & response)
  {
    if (!pub.nh_->connected()) return;
    ret = &response;
    waiting = true;
    pub.publish(&request);
    while (waiting && pub.nh_->connected())
      if (pub.nh_->spinOnce() < 0) break;
  }
```
So I change my code as below:

```
 roscpp_tutorials::TwoInts::Request req;
  roscpp_tutorials::TwoInts::Response res;
  ros::ServiceClient <roscpp_tutorials::TwoInts::Request, roscpp_tutorials::TwoInts::Response>
      client("/add_two_ints");
  req.a = int64_t(3);
  req.b = int64_t(4);
  nh.serviceClient(client);
    nh.serviceClient(client);
    //client.call(req, res);
    client.ret = &res;
    client.waiting = true;
    client.pub.publish(&req);
    while (client.waiting) {
        printf("=========");
        if (client.pub.nh_->spinOnce() < 0)
            break;

    }
```

Then the terminal have such log infos:

```
rosrun rosserial_server socket_node
[ INFO] [1611535710.993019300]: Listening for rosserial TCP connections on port 11411
[ INFO] [1611535838.401030000]: waitForService: Service [/service_info] has not been advertised, waiting...
[ WARN] [1611535843.415169100]: Timed out waiting for service_info service to become available.
[ WARN] [1611535843.417027600]: Failed to call service_info service. The service client will be created with blank md5sum.
[ WARN] [1611535843.418184600]: Service client setup: Request message MD5 mismatch between rosserial client and ROS
[ WARN] [1611535843.419765800]: Service client setup: Response message MD5 mismatch between rosserial client and ROS

```

I try to run the ` <node pkg="rosserial_python" type="message_info_service.py"
          name="rosserial_message_info"`

and it works.
But the result is wrong and still have logs warning.

===

```
ROS_WARN("Received message with unrecognized topicId (%d).", topic_id);
        // TODO: Resynchronize on multiples?

```

Tested in both ros-kinetic(linux) and ros-melodic(win).
rosserial_server version:  0.8.0
visual studio 2019