### PR TITLE
Gracefully handle socket server end.

### DIFF
--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -229,11 +229,15 @@ class RosSerialServer:
         #bind the socket to a public host, and a well-known port
         self.serversocket.bind(("", self.tcp_portnum)) #become a server socket
         self.serversocket.listen(1)
+        self.serversocket.settimeout(1)
 
-        while True:
-            #accept connections
-            rospy.loginfo("Waiting for socket connection")
-            clientsocket, address = self.serversocket.accept()
+        #accept connections
+        rospy.loginfo("Waiting for socket connection")
+        while not rospy.is_shutdown():
+            try:
+                clientsocket, address = self.serversocket.accept()
+            except socket.timeout:
+                continue
 
             #now do something with the clientsocket
             rospy.loginfo("Established a socket connection from %s on port %s" % address)


### PR DESCRIPTION
When stopping the socket server the `accept()` method blocks until SIGTERM, this is not pretty and takes time...

I suggest a 1 second timeout which fails silently continuously if no connection is present and allows to check for the `rospy.is_shutdown()` condition of the while loop to end gracefully and immediately.