### PR TITLE
Update SerialClient.py

### DIFF
--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -550,7 +550,6 @@ class SerialClient(object):
                 with self.write_lock:
                     self.port.flushOutput()
                 self.requestTopics()
-        # self.txStopRequest()
         self.write_thread.join()
 
     def setPublishSize(self, size):

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -345,7 +345,12 @@ class SerialClient(object):
         self.publishers = dict()  # id:Publishers
         self.subscribers = dict() # topic:Subscriber
         self.services = dict()    # topic:Service
-
+        
+        def shutdown():
+            self.txStopRequest()
+            rospy.loginfo('shutdown hook activated')
+        rospy.on_shutdown(shutdown)
+        
         self.pub_diagnostics = rospy.Publisher('/diagnostics', diagnostic_msgs.msg.DiagnosticArray, queue_size=10)
 
         if port is None:
@@ -545,7 +550,7 @@ class SerialClient(object):
                 with self.write_lock:
                     self.port.flushOutput()
                 self.requestTopics()
-        self.txStopRequest()
+        # self.txStopRequest()
         self.write_thread.join()
 
     def setPublishSize(self, size):


### PR DESCRIPTION
adds a shutdown hook for sending txStopRequest, and comments out the txtStopRequest before the thread_join.