### PR TITLE
Fix CMP0038 warning on CMake >= 3.0

### DIFF
--- a/rosserial_arduino/arduino-cmake/cmake/Platform/Arduino.cmake
+++ b/rosserial_arduino/arduino-cmake/cmake/Platform/Arduino.cmake
@@ -991,8 +991,12 @@ function(setup_arduino_library VAR_NAME BOARD_ID LIB_PATH COMPILE_FLAGS LINK_FLA
 
             foreach(LIB_DEP ${LIB_DEPS})
                 setup_arduino_library(DEP_LIB_SRCS ${BOARD_ID} ${LIB_DEP} "${COMPILE_FLAGS}" "${LINK_FLAGS}")
-                list(APPEND LIB_TARGETS ${DEP_LIB_SRCS})
-                list(APPEND LIB_INCLUDES ${DEP_LIB_SRCS_INCLUDES})
+                # Do not link to this library. DEP_LIB_SRCS will always be only one entry
+                # if we are looking at the same library.
+                if(NOT DEP_LIB_SRCS STREQUAL TARGET_LIB_NAME)
+                    list(APPEND LIB_TARGETS ${DEP_LIB_SRCS})
+                    list(APPEND LIB_INCLUDES ${DEP_LIB_SRCS_INCLUDES})
+                endif()
             endforeach()
 
             if (LIB_INCLUDES)


### PR DESCRIPTION
As of CMake 3.0 targets may not link to themselves when calling `target_link_libraries` (policy CMP0038), doing so will raise a warning and ignore targets linking to themselves. Trying to build on noetic, this is reported as an error.

Fix reflects PR to source: https://github.com/queezythegreat/arduino-cmake/pull/143