### PR TITLE
compatibility with Python3 for rosserial_arduino

### DIFF
--- a/rosserial_arduino/src/rosserial_arduino/__init__.py
+++ b/rosserial_arduino/src/rosserial_arduino/__init__.py
@@ -1,1 +1,1 @@
-from SerialClient import *
+from .SerialClient import *


### PR DESCRIPTION
This modification is required for Python3 to find the local `SerialClient` module