### PR TITLE
node_handle: spinOnce: add two new return codes

### DIFF
--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -67,6 +67,8 @@ namespace ros
 const int SPIN_OK = 0;
 const int SPIN_ERR = -1;
 const int SPIN_TIMEOUT = -2;
+const int SPIN_TX_STOP_REQUESTED = -3;
+const int SPIN_TIME_RECV = -4;
 
 const uint8_t SYNC_SECONDS  = 5;
 const uint8_t MODE_FIRST_FF = 0;
@@ -202,6 +204,9 @@ public:
       }
     }
 
+    bool tx_stop_requested = false;
+    bool saw_time_msg = false;
+
     /* while available buffer, read data */
     while (true)
     {
@@ -303,6 +308,7 @@ public:
           }
           else if (topic_ == TopicInfo::ID_TIME)
           {
+            saw_time_msg = true;
             syncTime(message_in);
           }
           else if (topic_ == TopicInfo::ID_PARAMETER_REQUEST)
@@ -313,6 +319,7 @@ public:
           else if (topic_ == TopicInfo::ID_TX_STOP)
           {
             configured_ = false;
+            tx_stop_requested = true;
           }
           else
           {
@@ -330,7 +337,7 @@ public:
       last_sync_time = c_time;
     }
 
-    return SPIN_OK;
+    return saw_time_msg ? SPIN_TIME_RECV : (tx_stop_requested ? SPIN_TX_STOP_REQUESTED : SPIN_OK);
   }
 
 


### PR DESCRIPTION
Adds two new return codes (backward compatible change):

SPIN_TX_STOP_REQUESTED
SPIN_TIME_RECV

They are returned as the name suggests to differentiate two states in
which currently SPIN_OK would have been returned.

This allows the caller to further use the return, i.e. issuing a log
message (that is always sent irrespective of connected status since ID <
100).

Signed-off-by: Alon Levy <alon.levy@bladeranger.com>