### PR TITLE
Remove ESP flags for ArduinoTcpHardware to use hardware serial

### DIFF
--- a/rosserial_arduino/src/ros_lib/examples/Esp8266HelloWorld/Esp8266HelloWorld.ino
+++ b/rosserial_arduino/src/ros_lib/examples/Esp8266HelloWorld/Esp8266HelloWorld.ino
@@ -9,6 +9,9 @@
  *
  */
 #include <ESP8266WiFi.h>
+
+#define ROSSERIAL_ARDUINO_TCP
+
 #include <ros.h>
 #include <std_msgs/String.h>
 

--- a/rosserial_arduino/src/ros_lib/ros.h
+++ b/rosserial_arduino/src/ros_lib/ros.h
@@ -37,7 +37,7 @@
 
 #include "ros/node_handle.h"
 
-#if defined(ESP8266) or defined(ESP32) or defined(ROSSERIAL_ARDUINO_TCP)
+#if defined(ROSSERIAL_ARDUINO_TCP)
   #include "ArduinoTcpHardware.h"
 #else
   #include "ArduinoHardware.h"


### PR DESCRIPTION
I want to use HardwareSerial with ESP32.
Could you consider removing ESP flags to activate ArduinoTcpHardware?

Thanks.