### PR TITLE
melodic backport of #562 (Made tcp_port a local parameter)

### DIFF
--- a/rosserial_python/nodes/serial_node.py
+++ b/rosserial_python/nodes/serial_node.py
@@ -55,8 +55,9 @@ if __name__=="__main__":
     # TIOCM_DTR_str) line, which causes an IOError, when using simulated port
     fix_pyserial_for_test = rospy.get_param('~fix_pyserial_for_test', False)
 
-    # TODO: should these really be global?
-    tcp_portnum = int(rospy.get_param('/rosserial_embeddedlinux/tcp_port', '11411'))
+    tcp_portnum = int(rospy.get_param('~tcp_port', '11411'))
+    
+    # TODO: should this really be global?
     fork_server = rospy.get_param('/rosserial_embeddedlinux/fork_server', False)
 
     # TODO: do we really want command line params in addition to parameter server params?

--- a/rosserial_python/nodes/serial_node.py
+++ b/rosserial_python/nodes/serial_node.py
@@ -55,10 +55,15 @@ if __name__=="__main__":
     # TIOCM_DTR_str) line, which causes an IOError, when using simulated port
     fix_pyserial_for_test = rospy.get_param('~fix_pyserial_for_test', False)
 
-    tcp_portnum = int(rospy.get_param('~tcp_port', '11411'))
+    if(rospy.has_param('~tcp_port')):
+        tcp_portnum = int(rospy.get_param('~tcp_port', '11411'))
+    else:
+        tcp_portnum = int(rospy.get_param('/rosserial_embeddedlinux/tcp_port', '11411'))
     
-    # TODO: should this really be global?
-    fork_server = rospy.get_param('/rosserial_embeddedlinux/fork_server', False)
+    if(rospy.has_param('~fork_server')):
+        fork_server = rospy.get_param('~fork_server', False)
+    else:
+        fork_server = rospy.get_param('/rosserial_embeddedlinux/fork_server', False)
 
     # TODO: do we really want command line params in addition to parameter server params?
     sys.argv = rospy.myargv(argv=sys.argv)

--- a/rosserial_python/nodes/serial_node.py
+++ b/rosserial_python/nodes/serial_node.py
@@ -55,13 +55,15 @@ if __name__=="__main__":
     # TIOCM_DTR_str) line, which causes an IOError, when using simulated port
     fix_pyserial_for_test = rospy.get_param('~fix_pyserial_for_test', False)
 
+    # Allows for assigning local parameters for tcp_port and fork_server with
+    # global parameters as fallback to prevent breaking changes 
     if(rospy.has_param('~tcp_port')):
-        tcp_portnum = int(rospy.get_param('~tcp_port', '11411'))
+        tcp_portnum = int(rospy.get_param('~tcp_port'))
     else:
         tcp_portnum = int(rospy.get_param('/rosserial_embeddedlinux/tcp_port', '11411'))
     
     if(rospy.has_param('~fork_server')):
-        fork_server = rospy.get_param('~fork_server', False)
+        fork_server = rospy.get_param('~fork_server')
     else:
         fork_server = rospy.get_param('/rosserial_embeddedlinux/fork_server', False)
 


### PR DESCRIPTION
This is backport of #562

> The tcp_port parameter being a global parameter prevents the launch of multiple serial nodes on different port numbers using a launch file


to melodic-devel branch