### PR TITLE
Add ArduinoBluetoothHardware and example

### DIFF
--- a/rosserial_arduino/src/ros_lib/ArduinoBluetoothBLEHardware.h
+++ b/rosserial_arduino/src/ros_lib/ArduinoBluetoothBLEHardware.h
@@ -1,0 +1,192 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2023, Kei Okada
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *  * Neither the name of copyright holder nor the names of its
+ *    contributors may be used to endorse or promote prducts derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Copied from esp32/hardware/esp32/2.0.9/libraries/BLE/examples/BLE_uart/BLE_uart.ino
+
+#ifndef ROS_ARDUINO_BLUETOOTH_BLE_HARDWARE_H_
+#define ROS_ARDUINO_BLUETOOTH_BLE_HARDWARE_H_
+
+#if not defined(ESP32)
+  #error ARDUINO BLUETOOTH HARDWARE CURRENTLY SUPPORT ONLY ESP32
+#endif
+
+#include <BLEDevice.h>
+#include <BLEServer.h>
+#include <BLEUtils.h>
+#include <BLE2902.h>
+
+// See the following for generating UUIDs:
+// https://www.uuidgenerator.net/
+
+#define SERVICE_UUID           "6E400001-B5A3-F393-E0A9-E50E24DCCA9E" // UART service UUID
+#define CHARACTERISTIC_UUID_RX "6E400002-B5A3-F393-E0A9-E50E24DCCA9E"
+#define CHARACTERISTIC_UUID_TX "6E400003-B5A3-F393-E0A9-E50E24DCCA9E"
+
+bool deviceConnected = false;
+
+class MyServerCallbacks: public BLEServerCallbacks {
+  void onConnect(BLEServer* pServer) {
+    deviceConnected = true;
+  };
+
+  void onDisconnect(BLEServer* pServer) {
+    deviceConnected = false;
+  }
+};
+
+#include <RingBuf.h>  // Need RingBuffer by Jean-Luc Locoduino
+
+RingBuf<int, 128> rx_buffer;
+class MyCallbacks: public BLECharacteristicCallbacks {
+  void onWrite(BLECharacteristic *pCharacteristic) {
+    std::string rxValue = pCharacteristic->getValue();
+
+    // Serial.print("onWrite  : ");
+    // Serial.println(rxValue.length());
+    if (rxValue.length() > 0) {
+      for (int i = 0; i < rxValue.length(); i++) {
+        rx_buffer.push(rxValue[i]);
+      }
+    }
+  }
+};
+
+class ArduinoHardware {
+public:
+  ArduinoHardware()
+  {
+  }
+
+  void init()
+  {
+    init("rosserial BLE UART Service");
+  }
+
+  void init(char *name)
+  {
+    // Create the BLE Device
+    BLEDevice::init(name);
+
+    // Create the BLE Server
+    pServer = BLEDevice::createServer();
+    pServer->setCallbacks(new MyServerCallbacks());
+
+    // Create the BLE Service
+    BLEService *pService = pServer->createService(SERVICE_UUID);
+
+    // Create a BLE Characteristic
+    pTxCharacteristic = pService->createCharacteristic(
+                                                       CHARACTERISTIC_UUID_TX,
+                                                       BLECharacteristic::PROPERTY_NOTIFY |
+                                                       BLECharacteristic::PROPERTY_READ
+                                                       );
+    pTxCharacteristic->addDescriptor(new BLE2902());
+
+    BLECharacteristic * pRxCharacteristic = pService->createCharacteristic(
+                                                                           CHARACTERISTIC_UUID_RX,
+                                                                           BLECharacteristic::PROPERTY_WRITE
+                                                                           );
+
+    pRxCharacteristic->setCallbacks(new MyCallbacks());
+
+    // Start the service
+    pService->start();
+
+    // Start advertising
+    pServer->getAdvertising()->start();
+    //Serial.println("Waiting a client connection to notify...");
+  }
+
+  int read(){
+    int data;
+    // Serial.print("read  : ");
+    // Serial.println(rx_buffer.size());
+    if (rx_buffer.lockedPop(data)) {
+      return data;
+    }
+    return -1;
+  }
+
+  void write(uint8_t* data, int length)
+  {
+    // Serial.print("write : ");
+    // Serial.println(length);
+    // Serial.println(ESP_GATT_MAX_ATTR_LEN);
+    size_t max_length = ESP_GATT_MAX_ATTR_LEN-100;
+    if (deviceConnected) {
+      for(size_t i = 0; i < length; i += max_length) {
+        // Serial.print("i = ");
+        // Serial.print(i);
+        // Serial.print(" / ");
+        // Serial.println(min(length-i, max_length));
+        pTxCharacteristic->setValue(data+i, (size_t)(min(length-i, max_length)));
+        pTxCharacteristic->notify();
+        delay(10); // bluetooth stack will go into congestion, if too many packets are sent
+      }
+      delay(20);
+    }
+    loop();
+  }
+
+  void loop() {
+    // disconnecting
+    if (!deviceConnected && oldDeviceConnected) {
+        delay(500); // give the bluetooth stack the chance to get things ready
+        pServer->startAdvertising(); // restart advertising
+        Serial.println("start advertising");
+        oldDeviceConnected = deviceConnected;
+    }
+    // connecting
+    if (deviceConnected && !oldDeviceConnected) {
+      // do stuff here on connecting
+      oldDeviceConnected = deviceConnected;
+    }
+  }
+
+  unsigned long time()
+  {
+    return millis();
+  }
+
+
+protected:
+  int rxvalue_length = 0;
+
+  BLEServer *pServer = NULL;
+  BLECharacteristic * pTxCharacteristic;
+  bool oldDeviceConnected = false;
+  uint8_t txValue = 0;
+};
+
+#endif

--- a/rosserial_arduino/src/ros_lib/ArduinoBluetoothHardware.h
+++ b/rosserial_arduino/src/ros_lib/ArduinoBluetoothHardware.h
@@ -32,38 +32,48 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _ROS_H_
-#define _ROS_H_
+#ifndef ROS_ARDUINO_BLUETOOTH_HARDWARE_H_
+#define ROS_ARDUINO_BLUETOOTH_HARDWARE_H_
 
-#include "ros/node_handle.h"
-
-#if defined(ROSSERIAL_ARDUINO_TCP)
-  #include "ArduinoTcpHardware.h"
-#elif defined(ROSSERIAL_ARDUINO_BLUETOOTH)
-  #include "ArduinoBluetoothHardware.h"
-#else
-  #include "ArduinoHardware.h"
+#if not defined(ESP32)
+  #error ARDUINO BLUETOOTH HARDWARE CURRENTLY SUPPORT ONLY ESP32
 #endif
 
-namespace ros
-{
-#if defined(__AVR_ATmega8__) or defined(__AVR_ATmega168__)
-  /* downsize our buffers */
-  typedef NodeHandle_<ArduinoHardware, 6, 6, 150, 150> NodeHandle;
+#include <Arduino.h>
+#include "BluetoothSerial.h"
 
-#elif defined(__AVR_ATmega328P__)
+class ArduinoHardware {
+public:
+  ArduinoHardware()
+  {
+  }
 
-  typedef NodeHandle_<ArduinoHardware, 25, 25, 280, 280> NodeHandle;
+  void init()
+  {
+    bluetooth_serial.begin("ROSSERIAL_BLUETOOTH");
+  }
 
-#elif defined(SPARK)
+  void init(char *name)
+  {
+    bluetooth_serial.begin(name);
+  }
 
-  typedef NodeHandle_<ArduinoHardware, 10, 10, 2048, 2048> NodeHandle;
+  int read(){
+    return bluetooth_serial.read();
+  }
 
-#else
+  void write(const uint8_t* data, int length)
+  {
+    bluetooth_serial.write(data, length);
+  }
 
-  typedef NodeHandle_<ArduinoHardware> NodeHandle; // default 25, 25, 512, 512
+  unsigned long time()
+  {
+    return millis();
+  }
 
-#endif
-}
+protected:
+  BluetoothSerial bluetooth_serial;
+};
 
 #endif

--- a/rosserial_arduino/src/ros_lib/examples/BluetoothHelloWorld/BluetoothHelloWorld.ino
+++ b/rosserial_arduino/src/ros_lib/examples/BluetoothHelloWorld/BluetoothHelloWorld.ino
@@ -9,6 +9,7 @@
  *   pair <MAC address>
  *   trust <MAC address>
  *   connect <MAC address>
+ *   info <MAC address> # check if successfully connected
  * After connect this device from PC, bind your device to serial device.
  *   sudo rfcomm bind 1 <MAC Address of your device>
  *   sudo stty -F /dev/rfcomm1 57600 cs8
@@ -16,7 +17,7 @@
  *   rosrun rosserial_python serial_node.py _port:=/dev/rfcomm1 _baud:=57600
  */
 
-#define ROSSERIAL_ARDUINO_BLUETOOTH
+#define ROSSERIAL_ARDUINO_BLUETOOTH // set this if you use rosserial over bluetooth
 
 #include <Arduino.h>
 #include <ros.h>

--- a/rosserial_arduino/src/ros_lib/examples/BluetoothHelloWorld/BluetoothHelloWorld.ino
+++ b/rosserial_arduino/src/ros_lib/examples/BluetoothHelloWorld/BluetoothHelloWorld.ino
@@ -15,6 +15,7 @@
 #include <ros.h>
 #include <std_msgs/String.h>
 
+ros::NodeHandle nh;
 std_msgs::String str_msg;
 ros::Publisher chatter("chatter", &str_msg);
 

--- a/rosserial_arduino/src/ros_lib/examples/BluetoothHelloWorld/BluetoothHelloWorld.ino
+++ b/rosserial_arduino/src/ros_lib/examples/BluetoothHelloWorld/BluetoothHelloWorld.ino
@@ -2,7 +2,14 @@
  * rosserial Publisher Example with ArduinoBluetoothHardware
  * Prints "hello world!"
  * This intends to be connected from bluetooth interface of host PC.
- * After pairing and trusting this device from PC, bind your device to serial device.
+ * First pair and connect to your esp32 after burning firmware.
+ *   bluetoothctl
+ *   scan on # check MAC address
+ *   scan off
+ *   pair <MAC address>
+ *   trust <MAC address>
+ *   connect <MAC address>
+ * After connect this device from PC, bind your device to serial device.
  *   sudo rfcomm bind 1 <MAC Address of your device>
  *   sudo stty -F /dev/rfcomm1 57600 cs8
  * then you can now connect rosserial host node to serial device

--- a/rosserial_arduino/src/ros_lib/examples/BluetoothHelloWorld/BluetoothHelloworld.ino
+++ b/rosserial_arduino/src/ros_lib/examples/BluetoothHelloWorld/BluetoothHelloworld.ino
@@ -1,0 +1,41 @@
+/**
+ * rosserial Publisher Example with ArduinoBluetoothHardware
+ * Prints "hello world!"
+ * This intends to be connected from bluetooth interface of host PC.
+ * After pairing and trusting this device from PC, bind your device to serial device.
+ *   sudo rfcomm bind 1 <MAC Address of your device>
+ *   sudo stty -F /dev/rfcomm1 57600 cs8
+ * then you can now connect rosserial host node to serial device
+ *   rosrun rosserial_python serial_node.py _port:=/dev/rfcomm1 _baud:=57600
+ */
+
+#define ROSSERIAL_ARDUINO_BLUETOOTH
+
+#include <Arduino.h>
+#include <ros.h>
+#include <std_msgs/String.h>
+
+std_msgs::String str_msg;
+ros::Publisher chatter("chatter", &str_msg);
+
+char hello[14] = "hello world!";
+
+void setup()
+{
+    nh.initNode("BluetoothHelloworld");
+    nh.advertise(chatter);
+
+    // wait for bluetooth and rosserial host connection.
+    while (not nh.connected()) {
+        nh.spinOnce();
+        delay(100);
+    }
+}
+
+void loop()
+{
+    str_msg.data = hello;
+    chatter.publish( &str_msg );
+    nh.spinOnce();
+    delay(1000);
+}


### PR DESCRIPTION
Add ArduinoBluetoothHardware.h and example for ESP32 Bluetooth Serial.

This PR enables rosserial connection over bluetooth of ESP32.
I don't know who originaly develop this usage, but already some uses this.

- ~~https://techtutorialsx.com/2018/03/09/esp32-arduino-serial-communication-over-bluetoth-hello-world/~~

I thinks this will be useful for otherESP32 rosserial users.

I confirmed that example program works with boards below

- ESP32-DevKitC-32E
- M5Stack Core
- M5Stack Core2
- M5StickC

# Usage

FIrst, burn the example sketch to your ESP32 board.
After that, connect your PC's bluetooth interface to esp32 board

```
bluetoothctl
scan on # check MAC address of your device
scan off
pair <MAC address of your device>
trust <MAC address of your device>
connect <MAC address of your device>
info <MAC address of your device> # check if your device is successfully connected
```

And bind bluetooth serial connection to /dev/rfcomm1

```
sudo rfcomm bind 1 <MAC address of your device>
sudo stty -F /dev/rfcomm1 57600 cs8
```

Now you can use rosserial over bluetooth

```
roscore
```

```
rosrun rosserial_python serial_node.py _port:=/dev/rfcomm1 _baud:=57600
```