### PR TITLE
Fix issue with Teensy 4.1 Ethernet connection will stuck and reboot

### DIFF
--- a/rosserial_arduino/src/ros_lib/ArduinoTcpHardware.h
+++ b/rosserial_arduino/src/ros_lib/ArduinoTcpHardware.h
@@ -78,7 +78,10 @@ public:
   int read(){
     if (tcp_.connected())
     {
-        return tcp_.read();
+        if(tcp_.available())
+        {
+            return tcp_.read();
+        }
     }
     else
     {


### PR DESCRIPTION
This fix issue #532 otherwise Teensy 4.1 with Ethernet connection will stuck.

https://github.com/ros-drivers/rosserial/issues/532

