### PR TITLE
Make explicit notice of original license/contributor in arduino-cmake

### DIFF
--- a/rosserial_arduino/arduino-cmake/cmake/Platform/Arduino.cmake
+++ b/rosserial_arduino/arduino-cmake/cmake/Platform/Arduino.cmake
@@ -1,4 +1,12 @@
 #=============================================================================#
+# Author: Tomasz Bogdal (QueezyTheGreat)
+# Home:   https://github.com/queezythegreat/arduino-cmake
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#=============================================================================#
+#=============================================================================#
 # generate_arduino_firmware(name
 #      [BOARD board_id]
 #      [SKETCH sketch_path |


### PR DESCRIPTION
IANAL and not acting on behalf of Tomasz Bogdal, the maintainer of https://github.com/queezythegreat/arduino-cmake

I noticed rosserial_arduino originally incorporated this code via git-submodule. Later the submodule was removed in favour of just having the necessary files. The code was licensed under MPL 2.0 but the README with the license notice was removed. 

It would be better to give explicit notice which files are derived and would be subject to the MPL.

(Again, not a lawyer. Please correct me)