### PR TITLE
Updates to arduino-cmake to support Teensy boards and small changes to rosserial_client and rosserial_python

### DIFF
--- a/rosserial_arduino/arduino-cmake/cmake/Platform/Arduino.cmake
+++ b/rosserial_arduino/arduino-cmake/cmake/Platform/Arduino.cmake
@@ -9,6 +9,7 @@
 #      [SERIAL serial_cmd]
 #      [PROGRAMMER programmer_id]
 #      [AFLAGS flags]
+#      [SETTINGS menu_settings]
 #      [NO_AUTOLIBS]
 #      [MANUAL])
 #
@@ -29,11 +30,12 @@
 #      SERIAL         # Serial command for serial target
 #      PROGRAMMER     # Programmer id (enables programmer support)
 #      AFLAGS         # Avrdude flags for target
+#      SETTINGS       # Menu settings (e.g. usb=serial speed=24)
 #      NO_AUTOLIBS    # Disables Arduino library detection
 #      MANUAL         # (Advanced) Only use AVR Libc/Includes
 #
 # Here is a short example for a target named test:
-#    
+#
 #       generate_arduino_firmware(
 #           NAME test
 #           SRCS test.cpp 
@@ -181,7 +183,7 @@
 #                          [BOARD  board_id]
 #                          [PORT port]
 #                          [SERIAL serial command]
-#                          [PORGRAMMER programmer_id]
+#                          [PROGRAMMER programmer_id]
 #                          [AFLAGS avrdude_flags])
 #=============================================================================#
 #
@@ -204,6 +206,12 @@
 # Print list of detected Arduino Boards.
 #
 #=============================================================================#
+# print_menu_list()
+#=============================================================================#
+#
+# Print list of detected menu settings.
+#
+#=============================================================================#
 # print_programmer_list()
 #=============================================================================#
 #
@@ -224,6 +232,15 @@
 #        ARDUINO_BOARD - Board id
 #
 # Print the detected Arduino board settings.
+#
+#=============================================================================#
+# print_menu_settings(BOARD_ID [MENUS])
+#=============================================================================#
+#
+#        BOARD_ID     - Board ID                               [REQUIRED]
+#        MENUS        - List of menus
+#
+# Print the possible menu settings for the given board (and menus, if given)
 #
 #=============================================================================#
 # register_hardware_platform(HARDWARE_PLATFORM_PATH)
@@ -317,6 +334,23 @@ endfunction()
 #=============================================================================#
 # [PUBLIC/USER]
 #
+# print_menu_list()
+#
+# see documentation at top
+#=============================================================================#
+function(PRINT_MENU_LIST)
+    foreach(PLATFORM ${ARDUINO_PLATFORMS})
+        if(${PLATFORM}_MENUS)
+            message(STATUS "${PLATFORM} menu settings:")
+            print_list(${PLATFORM}_MENUS "menu.SETTING")
+            message(STATUS "")
+        endif()
+    endforeach()
+endfunction()
+
+#=============================================================================#
+# [PUBLIC/USER]
+#
 # print_programmer_list()
 #
 # see documentation at top
@@ -355,6 +389,33 @@ function(PRINT_BOARD_SETTINGS ARDUINO_BOARD)
         message(STATUS "Arduino ${ARDUINO_BOARD} Board:")
         print_settings(${ARDUINO_BOARD})
     endif()
+endfunction()
+
+# [PUBLIC/USER]
+#
+# print_menu_settings(BOARD_ID [MENUS])
+#
+# see documentation at top
+function(PRINT_MENU_SETTINGS ARDUINO_BOARD)
+    if(NOT ${ARDUINO_BOARD}.menu.SETTINGS)
+        return()
+    elseif(${ARGC} LESS 2)
+        print_menu_settings(${ARDUINO_BOARD} ${${ARDUINO_BOARD}.menu.SETTINGS})
+        return()
+    endif()
+
+    foreach(MENU ${ARGN})
+        string(TOLOWER ${MENU} MENU)
+        list(FIND ${ARDUINO_BOARD}.menu.SETTINGS ${MENU} MENU_INDEX)
+        if(MENU_INDEX LESS 0)
+            continue()
+        endif()
+        message(STATUS "Arduino ${ARDUINO_BOARD} ${MENU} menu settings:")
+        foreach(MENU_SETTING ${${ARDUINO_BOARD}.menu.${MENU}.SUBSETTINGS})
+            message(STATUS "   ${MENU}.${MENU_SETTING}=${${ARDUINO_BOARD}.menu.${MENU}.${MENU_SETTING}}")
+        endforeach()
+        message(STATUS "")
+    endforeach()
 endfunction()
 
 #=============================================================================#
@@ -460,7 +521,7 @@ function(GENERATE_ARDUINO_FIRMWARE INPUT_NAME)
     parse_generator_arguments(${INPUT_NAME} INPUT
                               "NO_AUTOLIBS;MANUAL"                  # Options
                               "BOARD;PORT;SKETCH;PROGRAMMER"        # One Value Keywords
-                              "SERIAL;SRCS;HDRS;LIBS;ARDLIBS;AFLAGS"  # Multi Value Keywords
+                              "SERIAL;SRCS;HDRS;LIBS;ARDLIBS;AFLAGS;SETTINGS"  # Multi Value Keywords
                               ${ARGN})
 
     if(NOT INPUT_BOARD)
@@ -485,7 +546,7 @@ function(GENERATE_ARDUINO_FIRMWARE INPUT_NAME)
     set(LIB_DEP_INCLUDES)
 
     if(NOT INPUT_MANUAL)
-      setup_arduino_core(CORE_LIB ${INPUT_BOARD})
+      setup_arduino_core(CORE_LIB ${INPUT_BOARD} ${INPUT_SETTINGS})
     endif()
     
     if(NOT "${INPUT_SKETCH}" STREQUAL "")
@@ -508,7 +569,7 @@ function(GENERATE_ARDUINO_FIRMWARE INPUT_NAME)
     endforeach()
 
     if(NOT INPUT_NO_AUTOLIBS)
-        setup_arduino_libraries(ALL_LIBS  ${INPUT_BOARD} "${ALL_SRCS}" "${INPUT_ARDLIBS}" "${LIB_DEP_INCLUDES}" "")
+        setup_arduino_libraries(ALL_LIBS  ${INPUT_BOARD} "${ALL_SRCS}" "${INPUT_ARDLIBS}" "${LIB_DEP_INCLUDES}" "" ${INPUT_SETTINGS})
         foreach(LIB_INCLUDES ${ALL_LIBS_INCLUDES})
             arduino_debug_msg("Arduino Library Includes: ${LIB_INCLUDES}")
             set(LIB_DEP_INCLUDES "${LIB_DEP_INCLUDES} ${LIB_INCLUDES}")
@@ -517,7 +578,7 @@ function(GENERATE_ARDUINO_FIRMWARE INPUT_NAME)
     
     list(APPEND ALL_LIBS ${CORE_LIB} ${INPUT_LIBS})
 
-    setup_arduino_target(${INPUT_NAME} ${INPUT_BOARD} "${ALL_SRCS}" "${ALL_LIBS}" "${LIB_DEP_INCLUDES}" "" "${INPUT_MANUAL}")
+    setup_arduino_target(${INPUT_NAME} ${INPUT_BOARD} "${ALL_SRCS}" "${ALL_LIBS}" "${LIB_DEP_INCLUDES}" "" "${INPUT_MANUAL}" ${INPUT_SETTINGS})
 
     if(INPUT_PORT)
         setup_arduino_upload(${INPUT_BOARD} ${INPUT_NAME} ${INPUT_PORT} "${INPUT_PROGRAMMER}" "${INPUT_AFLAGS}")
@@ -689,7 +750,7 @@ function(REGISTER_HARDWARE_PLATFORM PLATFORM_PATH)
                 DOC "Path to Arduino boards definition file.")
 
             if(${PLATFORM}_BOARDS_PATH)
-                load_arduino_style_settings(${PLATFORM}_BOARDS "${${PLATFORM}_BOARDS_PATH}")
+                load_arduino_style_settings(${PLATFORM}_BOARDS "${${PLATFORM}_BOARDS_PATH}" ${PLATFORM}_MENUS)
             endif()
 
             if(${PLATFORM}_PROGRAMMERS_PATH)
@@ -781,44 +842,46 @@ endfunction()
 #=============================================================================#
 # [PRIVATE/INTERNAL]
 #
-# get_fcpu(FCPU BOARD_ID)
+# update_board_settings(BOARD_ID MENUS)
 #
-#       FCPU_VAR -Variable holding output
 #       BOARD_ID - The board id name
+#       MENUS    - Menus to update from
 #
-# Sets the the cpu speed for the specified Arduino Board (if not set).
+# Sets board setting variables from menu settings for the given menus.
+# For example, with board settings
+#
+# mega.menu.cpu.atmega2560=ATmega2560 (Mega 2560)
+#
+# mega.menu.cpu.atmega2560.upload.protocol=wiring
+# mega.menu.cpu.atmega2560.upload.maximum_size=253952
+# mega.menu.cpu.atmega2560.upload.speed=115200
+#
+# mega.menu.cpu.atmega1280=ATmega1280
+#
+# mega.menu.cpu.atmega1280.upload.protocol=arduino
+# mega.menu.cpu.atmega1280.upload.maximum_size=126976
+# mega.menu.cpu.atmega1280.upload.speed=57600
+#
+#
+# if mega.menu.cpu was set to atmega2560, then update_board_settings(mega cpu)
+# would create the following variables:
+#
+# set(mega.upload.protocol "wiring" PARENT_SCOPE)
+# set(mega.upload.maximum_size "253952" PARENT_SCOPE)
+# set(mega.upload.speed "115200" PARENT_SCOPE)
 #
 #=============================================================================#
-function(get_fcpu FCPU_VAR BOARD_ID)
-    set(FCPU)
-    if(DEFINED ${BOARD_ID}.build.f_cpu)
-        set(FCPU "${${BOARD_ID}.build.f_cpu}")
-    elseif(BOARD_ID STREQUAL "teensy41")
-        set(FCPU "600000000")
-    elseif(BOARD_ID STREQUAL "teensyMM")
-        set(FCPU "600000000")
-    elseif(BOARD_ID STREQUAL "teensy40")
-        set(FCPU "600000000")
-    elseif(BOARD_ID STREQUAL "teensy36")
-        set(FCPU "180000000")
-    elseif(BOARD_ID STREQUAL "teensy35")
-        set(FCPU "120000000")
-    elseif(BOARD_ID STREQUAL "teensy31")
-        set(FCPU "72000000")
-    elseif(BOARD_ID STREQUAL "teensy30")
-        set(FCPU "48000000")
-    elseif(BOARD_ID STREQUAL "teensyLC")
-        set(FCPU "48000000")
-    elseif(BOARD_ID STREQUAL "teensypp2")
-        set(FCPU "16000000L")
-    elseif(BOARD_ID STREQUAL "teensy2")
-        set(FCPU "16000000L")
-    else()
-        message(FATAL_ERROR "Failed to set CPU speed for ${BOARD_ID}")
-    endif()
-
-    # output 
-    set(${FCPU_VAR} "${FCPU}" PARENT_SCOPE)
+function(update_board_settings BOARD_ID)
+    foreach(MENU ${ARGN})
+        set(MENU_SETTING "${${BOARD_ID}.menu.${MENU}}")
+        if(NOT MENU_SETTING)
+            message(FATAL_ERROR "Failed to get settings for ${BOARD_ID}.menu.${MENU}")
+        endif()
+        foreach(SETTING ${${BOARD_ID}.menu.${MENU}.${MENU_SETTING}.SUBSUBSETTINGS})
+            set(${BOARD_ID}.${SETTING} "${${BOARD_ID}.menu.${MENU}.${MENU_SETTING}.${SETTING}}"
+                PARENT_SCOPE)
+        endforeach()
+    endforeach()
 endfunction()
 
 #=============================================================================#
@@ -853,10 +916,28 @@ function(get_arduino_flags COMPILE_FLAGS_VAR LINK_FLAGS_VAR BOARD_ID MANUAL)
             message("Invalid Arduino SDK Version (${ARDUINO_SDK_VERSION})")
         endif()
 
-        get_fcpu(${BOARD_ID}.build.f_cpu ${BOARD_ID})
+        set(MENUS)
+
+        # Update board settings from user menu settings
+        foreach(MENU_SETTING ${ARGN})
+            if(MENU_SETTING MATCHES "^([a-z]+)=([a-z]+)$")
+                set(${BOARD_ID}.menu.${CMAKE_MATCH_1} ${CMAKE_MATCH_2} CACHE INTERNAL "")
+                list(APPEND MENUS ${CMAKE_MATCH_1})
+            endif()
+        endforeach()
+
+        if(DEFINED TEENSY)
+            list(APPEND MENUS usb speed keys)
+        endif()
+
+        update_board_settings(${BOARD_ID} ${MENUS})
+
+        if(NOT ${BOARD_ID}.build.f_cpu)
+            set(${BOARD_ID}.build.f_cpu ${${BOARD_ID}.build.fcpu})
+        endif()
 
         # output
-        set(COMPILE_FLAGS "-DF_CPU=${${BOARD_ID}.build.f_cpu} -DARDUINO=${ARDUINO_VERSION_DEFINE} -DLAYOUT_US_ENGLISH")
+        set(COMPILE_FLAGS "-DF_CPU=${${BOARD_ID}.build.f_cpu} -DARDUINO=${ARDUINO_VERSION_DEFINE}")
         if(NOT DEFINED TEENSY)
             set(COMPILE_FLAGS "${COMPILE_FLAGS} -mmcu=${${BOARD_ID}.build.mcu}")
         elseif(BOARD_ID STREQUAL "teensy40")
@@ -864,7 +945,7 @@ function(get_arduino_flags COMPILE_FLAGS_VAR LINK_FLAGS_VAR BOARD_ID MANUAL)
         elseif(BOARD_ID STREQUAL "teensy41")
             set(COMPILE_FLAGS "${COMPILE_FLAGS} -DARDUINO_TEENSY41")
         endif()
-        foreach(CFLAGS common dep cpu defs)
+        foreach(CFLAGS common dep cpu defs optimize)
             set(COMPILE_FLAGS "${COMPILE_FLAGS} ${${BOARD_ID}.build.flags.${CFLAGS}}")
         endforeach()
         if(DEFINED ${BOARD_ID}.build.vid)
@@ -873,8 +954,11 @@ function(get_arduino_flags COMPILE_FLAGS_VAR LINK_FLAGS_VAR BOARD_ID MANUAL)
         if(DEFINED ${BOARD_ID}.build.pid)
             set(COMPILE_FLAGS "${COMPILE_FLAGS} -DUSB_PID=${${BOARD_ID}.build.pid}")
         endif()
-        if(DEFINED TEENSY_USB_MODE)
-            set(COMPILE_FLAGS "${COMPILE_FLAGS} -D${${BOARD_ID}.menu.usb.${TEENSY_USB_MODE}.build.usbtype}")
+        if(DEFINED ${BOARD_ID}.build.usbtype)
+            set(COMPILE_FLAGS "${COMPILE_FLAGS} -D${${BOARD_ID}.build.usbtype}")
+        endif()
+        if(DEFINED ${BOARD_ID}.build.keylayout)
+            set(COMPILE_FLAGS "${COMPILE_FLAGS} -DLAYOUT_${${BOARD_ID}.build.keylayout}")
         endif()
         if(NOT MANUAL)
             set(COMPILE_FLAGS "${COMPILE_FLAGS} -I\"${${BOARD_CORE}.path}\" -I\"${ARDUINO_LIBRARIES_PATH}\"")
@@ -951,7 +1035,7 @@ function(setup_arduino_core VAR_NAME BOARD_ID)
             # Debian/Ubuntu fix
             list(REMOVE_ITEM CORE_SRCS "${BOARD_CORE_PATH}/main.cxx")
             add_library(${CORE_LIB_NAME} ${CORE_SRCS})
-            get_arduino_flags(ARDUINO_COMPILE_FLAGS ARDUINO_LINK_FLAGS ${BOARD_ID} FALSE)
+            get_arduino_flags(ARDUINO_COMPILE_FLAGS ARDUINO_LINK_FLAGS ${BOARD_ID} FALSE ${ARGN})
             set_target_properties(${CORE_LIB_NAME} PROPERTIES
                 COMPILE_FLAGS "${ARDUINO_COMPILE_FLAGS}"
                 LINK_FLAGS "${ARDUINO_LINK_FLAGS}")
@@ -1080,12 +1164,12 @@ function(setup_arduino_library VAR_NAME BOARD_ID LIB_PATH COMPILE_FLAGS LINK_FLA
             arduino_debug_msg("Generating Arduino ${LIB_NAME} library")
             add_library(${TARGET_LIB_NAME} STATIC ${LIB_SRCS})
 
-            get_arduino_flags(ARDUINO_COMPILE_FLAGS ARDUINO_LINK_FLAGS ${BOARD_ID} FALSE)
+            get_arduino_flags(ARDUINO_COMPILE_FLAGS ARDUINO_LINK_FLAGS ${BOARD_ID} FALSE ${ARGN})
 
             find_arduino_libraries(LIB_DEPS "${LIB_SRCS}" "")
 
             foreach(LIB_DEP ${LIB_DEPS})
-                setup_arduino_library(DEP_LIB_SRCS ${BOARD_ID} ${LIB_DEP} "${COMPILE_FLAGS}" "${LINK_FLAGS}")
+                setup_arduino_library(DEP_LIB_SRCS ${BOARD_ID} ${LIB_DEP} "${COMPILE_FLAGS}" "${LINK_FLAGS}" ${ARGN})
                 # Do not link to this library. DEP_LIB_SRCS will always be only one entry
                 # if we are looking at the same library.
                 if(NOT DEP_LIB_SRCS STREQUAL TARGET_LIB_NAME)
@@ -1139,7 +1223,7 @@ function(setup_arduino_libraries VAR_NAME BOARD_ID SRCS ARDLIBS COMPILE_FLAGS LI
     find_arduino_libraries(TARGET_LIBS "${SRCS}" ARDLIBS)
     foreach(TARGET_LIB ${TARGET_LIBS})
         # Create static library instead of returning sources
-        setup_arduino_library(LIB_DEPS ${BOARD_ID} ${TARGET_LIB} "${COMPILE_FLAGS}" "${LINK_FLAGS}")
+        setup_arduino_library(LIB_DEPS ${BOARD_ID} ${TARGET_LIB} "${COMPILE_FLAGS}" "${LINK_FLAGS}" ${ARGN})
         list(APPEND LIB_TARGETS ${LIB_DEPS})
         list(APPEND LIB_INCLUDES ${LIB_DEPS_INCLUDES})
     endforeach()
@@ -1170,7 +1254,7 @@ function(setup_arduino_target TARGET_NAME BOARD_ID ALL_SRCS ALL_LIBS COMPILE_FLA
     add_executable(${TARGET_NAME} ${ALL_SRCS})
     set_target_properties(${TARGET_NAME} PROPERTIES SUFFIX ".elf")
 
-    get_arduino_flags(ARDUINO_COMPILE_FLAGS ARDUINO_LINK_FLAGS  ${BOARD_ID} ${MANUAL})
+    get_arduino_flags(ARDUINO_COMPILE_FLAGS ARDUINO_LINK_FLAGS  ${BOARD_ID} ${MANUAL} ${ARGN})
 
     set_target_properties(${TARGET_NAME} PROPERTIES
                 COMPILE_FLAGS "${ARDUINO_COMPILE_FLAGS} ${COMPILE_FLAGS}"
@@ -1645,41 +1729,68 @@ endfunction()
 #=============================================================================#
 # [PRIVATE/INTERNAL]
 #
-# load_arduino_style_settings(SETTINGS_LIST SETTINGS_PATH)
+# load_arduino_style_settings(SETTINGS_LIST SETTINGS_PATH [MENUS_LIST])
 #
 #      SETTINGS_LIST - Variable name of settings list
 #      SETTINGS_PATH - File path of settings file to load.
+#      MENUS_LIST    - Variable name of menus list (optional)
 #
 # Load a Arduino style settings file into the cache.
 # 
 #  Examples of this type of settings file is the boards.txt and
 # programmers.txt files located in ${ARDUINO_SDK}/hardware/arduino.
 #
-# Settings have to following format:
+# Settings have one of the following formats:
 #
 #      entry.setting[[.subsetting].subsubsetting] = value
+#      entry.menu.setting[[.subsetting].subsubsetting] = value
 #
 # where [[.subsetting].subsubsetting] is optional
 #
 # For example, the following settings:
 #
-#      uno.name=Arduino Uno
-#      uno.upload.protocol=stk500
-#      uno.upload.maximum_size=32256
-#      uno.build.mcu=atmega328p
-#      uno.build.core=arduino
+#      menu.cpu=Processor
 #
-# will generate the follwoing equivalent CMake variables:
+#      nano.name=Arduino Nano
+#      nano.upload.tool=avrdude
+#      nano.upload.protocol=arduino
+#      nano.build.f_cpu=16000000L
+#      nano.build.board=AVR_NANO
+#      nano.build.core=arduino
 #
-#      set(uno.name "Arduino Uno")
-#      set(uno.upload.protocol     "stk500")
-#      set(uno.upload.maximum_size "32256")
-#      set(uno.build.mcu  "atmega328p")
-#      set(uno.build.core "arduino")
+#      nano.menu.cpu.atmega328=ATmega328P
 #
-#      set(uno.SETTINGS  name upload build)              # List of settings for uno
-#      set(uno.upload.SUBSETTINGS protocol maximum_size) # List of sub-settings for uno.upload
-#      set(uno.build.SUBSETTINGS mcu core)               # List of sub-settings for uno.build
+#      nano.menu.cpu.atmega328.upload.maximum_size=30720
+#      nano.menu.cpu.atmega328.upload.maximum_data_size=2048
+#      nano.menu.cpu.atmega328.upload.speed=115200
+#
+#      nano.menu.cpu.atmega328old=ATmega328P (Old Bootloader)
+#
+#      nano.menu.cpu.atmega328old.upload.maximum_size=30720
+#      nano.menu.cpu.atmega328old.upload.maximum_data_size=2048
+#      nano.menu.cpu.atmega328old.upload.speed=57600
+#
+# will generate the following equivalent CMake variables:
+#
+#      set(menu.cpu "Processor")
+#
+#      set(nano.name "Arduino Nano")
+#      set(nano.upload.tool     "avrdude")
+#      set(nano.upload.protocol "arduino")
+#      set(nano.build.f_cpu     "16000000L")
+#      set(nano.build.board     "AVR_NANO")
+#      set(nano.build.core      "arduino")
+#
+#      set(nano.SETTINGS name upload build)         # List of settings for nano
+#      set(nano.upload.SUBSETTINGS tool protocol)   # List of sub-settings for nano.upload
+#      set(nano.build.SUBSETTINGS f_cpu board core) # List of sub-settings for nano.build
+#
+#      set(nano.menu.SETTINGS cpu)
+#      set(nano.menu.cpu.SUBSETTINGS atmega328 atmega328old)
+#      set(nano.menu.cpu.atmega328.SUBSUBSETTINGS
+#          upload.maximum_size upload.maximum_data_size upload.speed)
+#      set(nano.menu.cpu.atmega328old.SUBSUBSETTINGS
+#          upload.maximum_size upload.maximum_data_size upload.speed)
 # 
 #  The ${ENTRY_NAME}.SETTINGS variable lists all settings for the entry, while
 # ${ENTRY_NAME}.${ENTRY_SETTING}.SUBSETTINGS variables list all settings for a
@@ -1706,15 +1817,27 @@ function(LOAD_ARDUINO_STYLE_SETTINGS SETTINGS_LIST SETTINGS_PATH)
 
             # Add entry to settings list if it does not exist
             list(POP_FRONT ENTRY_NAME_TOKENS ENTRY_NAME)
-            list(FIND ${SETTINGS_LIST} ${ENTRY_NAME} ENTRY_NAME_INDEX)
-            if(ENTRY_NAME_INDEX LESS 0)
-                # Add entry to main list
-                list(APPEND ${SETTINGS_LIST} ${ENTRY_NAME})
+            if(NOT (ENTRY_NAME STREQUAL "menu"))
+                list(FIND ${SETTINGS_LIST} ${ENTRY_NAME} ENTRY_NAME_INDEX)
+                if(ENTRY_NAME_INDEX LESS 0)
+                    # Add entry to main list
+                    list(APPEND ${SETTINGS_LIST} ${ENTRY_NAME})
+                endif()
+            elseif(ARGC GREATER 2)
+                list(JOIN ENTRY_NAME_TOKENS "." MENU_SETTING)
+                list(APPEND ${ARGN} ${MENU_SETTING})
+            endif()
+
+            # Handle menu settings separately
+            list(POP_FRONT ENTRY_NAME_TOKENS ENTRY_SETTING)
+            if(ENTRY_SETTING STREQUAL "menu")
+                set(ENTRY_NAME "${ENTRY_NAME}.menu")
+                list(POP_FRONT ENTRY_NAME_TOKENS ENTRY_SETTING)
+                math(EXPR ENTRY_NAME_TOKENS_LEN "${ENTRY_NAME_TOKENS_LEN}-1")
             endif()
 
             # Add entry setting to entry settings list if it does not exist
             set(ENTRY_SETTING_LIST ${ENTRY_NAME}.SETTINGS)
-            list(POP_FRONT ENTRY_NAME_TOKENS ENTRY_SETTING)
             list(FIND ${ENTRY_SETTING_LIST} ${ENTRY_SETTING} ENTRY_SETTING_INDEX)
             if(ENTRY_SETTING_INDEX LESS 0)
                 # Add setting to entry
@@ -1761,6 +1884,10 @@ function(LOAD_ARDUINO_STYLE_SETTINGS SETTINGS_LIST SETTINGS_PATH)
     set(${SETTINGS_LIST} ${${SETTINGS_LIST}}
         CACHE STRING "List of detected Arduino Board configurations")
     mark_as_advanced(${SETTINGS_LIST})
+    if(ARGC GREATER 2)
+        set(${ARGN} ${${ARGN}} CACHE STRING "List of detected menu settings")
+        mark_as_advanced(${ARGN})
+    endif()
     endif()
 endfunction()
 
@@ -1784,6 +1911,11 @@ function(PRINT_SETTINGS ENTRY_NAME)
                     if(${ENTRY_NAME}.${ENTRY_SETTING}.${ENTRY_SUBSETTING})
                         message(STATUS "   ${ENTRY_NAME}.${ENTRY_SETTING}.${ENTRY_SUBSETTING}=${${ENTRY_NAME}.${ENTRY_SETTING}.${ENTRY_SUBSETTING}}")
                     endif()
+                    if(${ENTRY_NAME}.${ENTRY_SETTING}.${ENTRY_SUBSETTING}.SUBSUBSETTINGS)
+                        foreach(ENTRY_SUBSUBSETTING ${${ENTRY_NAME}.${ENTRY_SETTING}.${ENTRY_SUBSETTING}.SUBSUBSETTINGS})
+                            message(STATUS "   ${ENTRY_NAME}.${ENTRY_SETTING}.${ENTRY_SUBSETTING}.${ENTRY_SUBSUBSETTING}=${${ENTRY_NAME}.${ENTRY_SETTING}.${ENTRY_SUBSETTING}.${ENTRY_SUBSUBSETTING}}")
+                        endforeach()
+                    endif()
                 endforeach()
             endif()
             message(STATUS "")
@@ -1794,14 +1926,19 @@ endfunction()
 #=============================================================================#
 # [PRIVATE/INTERNAL]
 #
-# print_list(SETTINGS_LIST)
+# print_list(SETTINGS_LIST [PATTERN])
 #
-#      SETTINGS_LIST - Variables name of settings list
+#      SETTINGS_LIST - Variables name of settings list [REQUIRED]
+#      PATTERN       - Print values from pattern (default "SETTING.name")
 #
-# Print list settings and names (see load_arduino_syle_settings()).
+# Print list settings and names (values) (see load_arduino_syle_settings()).
 #=============================================================================#
 function(PRINT_LIST SETTINGS_LIST)
     if(${SETTINGS_LIST})
+        set(ENTRY_PATTERN "SETTING.name")
+        if(${ARGC} GREATER 1)
+            set(ENTRY_PATTERN "${ARGN}")
+        endif()
         set(MAX_LENGTH 0)
         foreach(ENTRY_NAME ${${SETTINGS_LIST}})
             string(LENGTH "${ENTRY_NAME}" CURRENT_LENGTH)
@@ -1816,7 +1953,8 @@ function(PRINT_LIST SETTINGS_LIST)
             foreach(X RANGE ${PADDING_LENGTH})
                 set(PADDING "${PADDING} ")
             endforeach()
-            message(STATUS "   ${PADDING}${ENTRY_NAME}: ${${ENTRY_NAME}.name}")
+            string(REPLACE "SETTING" "${ENTRY_NAME}" ENTRY_VALUE_NAME "${ENTRY_PATTERN}")
+            message(STATUS "   ${PADDING}${ENTRY_NAME}: ${${ENTRY_VALUE_NAME}}")
         endforeach()
     endif()
 endfunction()
@@ -2420,7 +2558,7 @@ if(NOT ARDUINO_FOUND AND ARDUINO_SDK_PATH)
         AVRSIZE_PROGRAM)
 endif()
 
-if(DEFINED TEENSY)
+if(NOT TEENSY_FOUND AND DEFINED TEENSY)
     register_hardware_platform(${ARDUINO_SDK_PATH}/hardware/teensy/)
 
     find_file(TEENSY_LIBRARIES_PATH
@@ -2481,14 +2619,15 @@ if(DEFINED TEENSY)
     #print_board_list()
     #print_programmer_list()
 
-    if(NOT DEFINED TEENSY_USB_MODE)
-        set(TEENSY_USB_MODE "SERIAL")
-    endif()
-    string(REPLACE "_" "" TEENSY_USB_MODE ${TEENSY_USB_MODE})
-    string(TOLOWER ${TEENSY_USB_MODE} TEENSY_USB_MODE)
-    set(TEENSY_USB_MODE "${TEENSY_USB_MODE}" CACHE STRING "What kind of USB device the Teensy should emulate")
-    #set_property(CACHE TEENSY_USB_MODE PROPERTY STRINGS serial hid serialhid midi rawhid flightsim)
+    # set default menu options
+    foreach(BOARD ${TEENSY_BOARDS})
+        foreach(MENU ${TEENSY_MENUS})
+            list(GET ${BOARD}.menu.${MENU}.SUBSETTINGS 0 ${BOARD}.menu.${MENU})
+            set(${BOARD}.menu.${MENU} "${${BOARD}.menu.${MENU}}" CACHE INTERNAL "${BOARD} ${MENU} menu setting")
+        endforeach()
+    endforeach()
 
+    set(TEENSY_FOUND True CACHE INTERNAL "Teensy Found")
     mark_as_advanced(
         TEENSY_PLATFORM_PATH
         TEENSY_CORES_PATH

--- a/rosserial_arduino/arduino-cmake/cmake/Teensy2Toolchain.cmake
+++ b/rosserial_arduino/arduino-cmake/cmake/Teensy2Toolchain.cmake
@@ -1,0 +1,23 @@
+# Add current directory to CMake Module path automatically
+if(EXISTS  ${CMAKE_CURRENT_LIST_DIR}/Platform/Arduino.cmake)
+    set(CMAKE_MODULE_PATH  ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_LIST_DIR})
+endif()
+ 
+include(ArduinoToolchain)
+
+set(TEENSY "" CACHE STRING "Using one of the Teensy boards")
+
+set(CMAKE_C_COMPILER "avr-gcc")
+set(CMAKE_CXX_COMPILER "avr-g++")
+set(CMAKE_AR "avr-ar")
+set(CMAKE_LINKER "avr-ld")
+set(CMAKE_NM "avr-nm")
+set(CMAKE_OBJCOPY "avr-objcopy")
+set(CMAKE_OBJDUMP "avr-objdump")
+set(CMAKE_STRIP "avr-strip")
+set(CMAKE_RANLIB "avr-ranlib")
+
+set(CMAKE_EXE_LINKER_FLAGS "--specs=nosys.specs" CACHE INTERNAL "")
+
+set(ARDUINO_C_FLAGS "-ffunction-sections -fdata-sections")
+set(ARDUINO_CXX_FLAGS "-fno-exceptions -fpermissive -felide-constructors -std=gnu++11")

--- a/rosserial_arduino/arduino-cmake/cmake/TeensyToolchain.cmake
+++ b/rosserial_arduino/arduino-cmake/cmake/TeensyToolchain.cmake
@@ -4,6 +4,10 @@ if(EXISTS  ${CMAKE_CURRENT_LIST_DIR}/Platform/Arduino.cmake)
 endif()
  
 include(ArduinoToolchain)
+
+list(APPEND CMAKE_SYSTEM_PREFIX_PATH ${ARDUINO_SDK_PATH}/hardware/tools/arm)
+list(APPEND CMAKE_SYSTEM_PREFIX_PATH ${ARDUINO_SDK_PATH}/hardware/tools/arm/arm-none-eabi)
+
 set(TEENSY "" CACHE STRING "Using one of the Teensy boards")
 set(CMAKE_SYSTEM_NAME Arduino)
 set(CMAKE_SYSTEM_PROCESSOR arm)

--- a/rosserial_arduino/arduino-cmake/cmake/TeensyToolchain.cmake
+++ b/rosserial_arduino/arduino-cmake/cmake/TeensyToolchain.cmake
@@ -1,0 +1,28 @@
+# Add current directory to CMake Module path automatically
+if(EXISTS  ${CMAKE_CURRENT_LIST_DIR}/Platform/Arduino.cmake)
+    set(CMAKE_MODULE_PATH  ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_LIST_DIR})
+endif()
+ 
+include(ArduinoToolchain)
+set(TEENSY "" CACHE STRING "Using one of the Teensy boards")
+set(CMAKE_SYSTEM_NAME Arduino)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+set(CMAKE_CROSSCOMPILING 1)
+
+set(CMAKE_C_COMPILER "arm-none-eabi-gcc")
+set(CMAKE_CXX_COMPILER "arm-none-eabi-g++")
+set(CMAKE_AR "arm-none-eabi-ar")
+set(CMAKE_LINKER "arm-none-eabi-ld")
+set(CMAKE_NM "arm-none-eabi-nm")
+set(CMAKE_OBJCOPY "arm-none-eabi-objcopy")
+set(CMAKE_OBJDUMP "arm-none-eabi-objdump")
+set(CMAKE_STRIP "arm-none-eabi-strip")
+set(CMAKE_RANLIB "arm-none-eabi-ranlib")
+
+set(CMAKE_EXE_LINKER_FLAGS "--specs=nosys.specs" CACHE INTERNAL "")
+
+set(ARDUINO_C_FLAGS "-ffunction-sections -fdata-sections")
+set(ARDUINO_CXX_FLAGS "-std=gnu++14 -fno-exceptions -fpermissive -fno-rtti -fno-threadsafe-statics -felide-constructors -Wno-error=narrowing")
+set(ARDUINO_OPT_FLAGS "-O2")
+
+include(Platform/Arduino)

--- a/rosserial_arduino/arduino-cmake/cmake/TeensyToolchain.cmake
+++ b/rosserial_arduino/arduino-cmake/cmake/TeensyToolchain.cmake
@@ -9,7 +9,6 @@ list(APPEND CMAKE_SYSTEM_PREFIX_PATH ${ARDUINO_SDK_PATH}/hardware/tools/arm)
 list(APPEND CMAKE_SYSTEM_PREFIX_PATH ${ARDUINO_SDK_PATH}/hardware/tools/arm/arm-none-eabi)
 
 set(TEENSY "" CACHE STRING "Using one of the Teensy boards")
-set(CMAKE_SYSTEM_NAME Arduino)
 set(CMAKE_SYSTEM_PROCESSOR arm)
 set(CMAKE_CROSSCOMPILING 1)
 
@@ -27,6 +26,3 @@ set(CMAKE_EXE_LINKER_FLAGS "--specs=nosys.specs" CACHE INTERNAL "")
 
 set(ARDUINO_C_FLAGS "-ffunction-sections -fdata-sections")
 set(ARDUINO_CXX_FLAGS "-std=gnu++14 -fno-exceptions -fpermissive -fno-rtti -fno-threadsafe-statics -felide-constructors -Wno-error=narrowing")
-set(ARDUINO_OPT_FLAGS "-O2")
-
-include(Platform/Arduino)

--- a/rosserial_arduino/cmake/rosserial_arduino-extras.cmake.em
+++ b/rosserial_arduino/cmake/rosserial_arduino-extras.cmake.em
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.7.2)
 
 @[if DEVELSPACE]@
 set(ROSSERIAL_ARDUINO_TOOLCHAIN "@(CMAKE_CURRENT_SOURCE_DIR)/arduino-cmake/cmake/ArduinoToolchain.cmake")
+set(ROSSERIAL_TEENSY_TOOLCHAIN "@(CMAKE_CURRENT_SOURCE_DIR)/arduino-cmake/cmake/TeensyToolchain.cmake")
 @[else]@
 set(ROSSERIAL_ARDUINO_TOOLCHAIN "${rosserial_arduino_DIR}/../arduino-cmake/cmake/ArduinoToolchain.cmake")
+set(ROSSERIAL_TEENSY_TOOLCHAIN "${rosserial_arduino_DIR}/../arduino-cmake/cmake/TeensyToolchain.cmake")
 @[end if]@
 

--- a/rosserial_arduino/cmake/rosserial_arduino-extras.cmake.em
+++ b/rosserial_arduino/cmake/rosserial_arduino-extras.cmake.em
@@ -3,8 +3,10 @@ cmake_minimum_required(VERSION 3.7.2)
 @[if DEVELSPACE]@
 set(ROSSERIAL_ARDUINO_TOOLCHAIN "@(CMAKE_CURRENT_SOURCE_DIR)/arduino-cmake/cmake/ArduinoToolchain.cmake")
 set(ROSSERIAL_TEENSY_TOOLCHAIN "@(CMAKE_CURRENT_SOURCE_DIR)/arduino-cmake/cmake/TeensyToolchain.cmake")
+set(ROSSERIAL_TEENSY2_TOOLCHAIN "@(CMAKE_CURRENT_SOURCE_DIR)/arduino-cmake/cmake/Teensy2Toolchain.cmake")
 @[else]@
 set(ROSSERIAL_ARDUINO_TOOLCHAIN "${rosserial_arduino_DIR}/../arduino-cmake/cmake/ArduinoToolchain.cmake")
 set(ROSSERIAL_TEENSY_TOOLCHAIN "${rosserial_arduino_DIR}/../arduino-cmake/cmake/TeensyToolchain.cmake")
+set(ROSSERIAL_TEENSY2_TOOLCHAIN "${rosserial_arduino_DIR}/../arduino-cmake/cmake/Teensy2Toolchain.cmake")
 @[end if]@
 

--- a/rosserial_arduino/nodes/serial_node.py
+++ b/rosserial_arduino/nodes/serial_node.py
@@ -56,6 +56,16 @@ if __name__=="__main__":
     # TIOCM_DTR_str) line, which causes an IOError, when using simulated port
     fix_pyserial_for_test = rospy.get_param('~fix_pyserial_for_test', False)
 
+    # for cases where waiting for data and/or callbacks is problematic
+    # e.g. when using high speed USB with specific timing constraints
+    fast_read = rospy.get_param('~fast_read', False)
+    if fast_read:
+        read_wait = False
+        callback_wait = False
+    else:
+        read_wait = rospy.get_param('~read_wait', True)
+        callback_wait = rospy.get_param('~callback_wait', True)
+
     # TODO: do we really want command line params in addition to parameter server params?
     sys.argv = rospy.myargv(argv=sys.argv)
     if len(sys.argv) >= 2 :
@@ -65,7 +75,7 @@ if __name__=="__main__":
         rospy.loginfo("Connecting to %s at %d baud" % (port_name, baud))
         try:
             client = SerialClient(port_name, baud, fix_pyserial_for_test=fix_pyserial_for_test, auto_reset_timeout=auto_reset_timeout)
-            client.run()
+            client.run(read_wait, callback_wait)
         except KeyboardInterrupt:
             break
         except SerialException:

--- a/rosserial_arduino/src/rosserial_arduino/make_libraries_hardfloat64.py
+++ b/rosserial_arduino/src/rosserial_arduino/make_libraries_hardfloat64.py
@@ -33,13 +33,13 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-THIS_PACKAGE = "rosserial_embeddedlinux"
+THIS_PACKAGE = "rosserial_arduino"
 
 __usage__ = """
-make_libraries.py generates the rosserial library files.  It
-requires the location of your project folder.
+make_libraries.py generates the Arduino rosserial library files.  It
+requires the location of your Arduino sketchbook/libraries folder.
 
-rosrun rosserial_embeddedlinux make_libraries.py <output_path>
+rosrun rosserial_arduino make_libraries_hardfloat64.py <output_path>
 """
 
 import rospkg
@@ -78,8 +78,7 @@ if (len(sys.argv) < 2):
 # get output path
 path = sys.argv[1]
 output_path = os.path.join(sys.argv[1], "ros_lib")
-examples_path = os.path.join(sys.argv[1], "examples")
-print("\nExporting to %s and %s" % (output_path, examples_path))
+print("\nExporting to %s" % output_path)
 
 rospack = rospkg.RosPack()
 
@@ -87,7 +86,6 @@ rospack = rospkg.RosPack()
 shutil.rmtree(output_path, ignore_errors=True)
 shutil.copytree(os.path.join(rospack.get_path(THIS_PACKAGE), "src", "ros_lib"), output_path)
 rosserial_client_copy_files(rospack, output_path)
-shutil.copytree(os.path.join(rospack.get_path(THIS_PACKAGE), "src", "examples"), examples_path)
 
 # generate messages
 rosserial_generate(rospack, output_path, ROS_TO_EMBEDDED_TYPES)

--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -371,14 +371,34 @@ public:
     last_sync_receive_time = hardware_.time();
   }
 
+  Time then(Time time)
+  {
+    time.sec += sec_offset;
+    time.nsec += nsec_offset;
+    normalizeSecNSec(time.sec, time.nsec);
+    return time;
+  }
+
+  Time then(uint32_t sec, uint32_t nsec)
+  {
+    return then(Time(sec, nsec));
+  }
+
+  Time then(uint32_t ms)
+  {
+    return then(ms / 1000, (ms % 1000) * 1000000UL);
+  }
+
+  Time then(double sec)
+  {
+    Time time;
+    time.fromSec(sec);
+    return then(time);
+  }
+
   Time now()
   {
-    uint32_t ms = hardware_.time();
-    Time current_time;
-    current_time.sec = ms / 1000 + sec_offset;
-    current_time.nsec = (ms % 1000) * 1000000UL + nsec_offset;
-    normalizeSecNSec(current_time.sec, current_time.nsec);
-    return current_time;
+    return then(hardware_.time());
   }
 
   void setNow(const Time & new_now)

--- a/rosserial_client/src/ros_lib/tf/transform_broadcaster.h
+++ b/rosserial_client/src/ros_lib/tf/transform_broadcaster.h
@@ -51,11 +51,11 @@ public:
     nh.advertise(publisher_);
   }
 
-  void sendTransform(geometry_msgs::TransformStamped &transform)
+  int sendTransform(geometry_msgs::TransformStamped &transform)
   {
     internal_msg.transforms_length = 1;
     internal_msg.transforms = &transform;
-    publisher_.publish(&internal_msg);
+    return publisher_.publish(&internal_msg);
   }
 
 private:

--- a/rosserial_python/nodes/serial_node.py
+++ b/rosserial_python/nodes/serial_node.py
@@ -54,6 +54,16 @@ if __name__=="__main__":
     # TIOCM_DTR_str) line, which causes an IOError, when using simulated port
     fix_pyserial_for_test = rospy.get_param('~fix_pyserial_for_test', False)
 
+    # for cases where waiting for data and/or callbacks is problematic
+    # e.g. when using high speed USB with specific timing constraints
+    fast_read = rospy.get_param('~fast_read', False)
+    if fast_read:
+        read_wait = False
+        callback_wait = False
+    else:
+        read_wait = rospy.get_param('~read_wait', True)
+        callback_wait = rospy.get_param('~callback_wait', True)
+
     # Allows for assigning local parameters for tcp_port and fork_server with
     # global parameters as fallback to prevent breaking changes 
     if(rospy.has_param('~tcp_port')):
@@ -93,7 +103,7 @@ if __name__=="__main__":
             rospy.loginfo("Connecting to %s at %d baud" % (port_name,baud) )
             try:
                 client = SerialClient(port_name, baud, fix_pyserial_for_test=fix_pyserial_for_test)
-                client.run()
+                client.run(read_wait, callback_wait)
             except KeyboardInterrupt:
                 break
             except SerialException:

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -444,7 +444,7 @@ class SerialClient(object):
         except Exception as e:
             raise IOError("Serial Port read failure: %s" % e)
 
-    def run(self):
+    def run(self, read_wait=True, callback_wait=True):
         """ Forward recieved messages to appropriate publisher. """
 
         # Launch write thread.
@@ -472,7 +472,7 @@ class SerialClient(object):
             # bottom attempts to reconfigure the topics.
             try:
                 with self.read_lock:
-                    if self.port.inWaiting() < 1:
+                    if read_wait and self.port.inWaiting() < 1:
                         time.sleep(0.001)
                         continue
 
@@ -540,7 +540,8 @@ class SerialClient(object):
                     except KeyError:
                         rospy.logerr("Tried to publish before configured, topic id %d" % topic_id)
                         self.requestTopics()
-                    time.sleep(0.001)
+                    if callback_wait:
+                        time.sleep(0.001)
                 else:
                     rospy.loginfo("wrong checksum for topic id and msg")
 


### PR DESCRIPTION
Updated rosserial_arduino for use with Teensy boards (see [corresponding arduino-cmake PR](https://github.com/queezythegreat/arduino-cmake/pull/187)). Also added some utility functions to `NodeHandleBase` and changed return type of `sendTransform` to `int` (because `publish` returns this anyway). Added a script `make_libraries_hardfloat64.py` to allow generating libraries using double rather than float (newer Teensy boards have FPU hardware). Also added a flag to `serial_node.py` to allow for faster USB reading in applications with tight timing constraints.