### PR TITLE
fixed nh.getParam template with gcc-arm-none-eabi

### DIFF
--- a/rosserial_client/src/ros_lib/ros/node_handle.h
+++ b/rosserial_client/src/ros_lib/ros/node_handle.h
@@ -572,7 +572,7 @@ protected:
   }
 
 public:
-  bool getParam(const char* name, int* param, int length = 1, int timeout = 1000)
+  bool getParam(const char* name, int32_t* param, int length = 1, int timeout = 1000)
   {
     if (requestParam(name, timeout))
     {


### PR DESCRIPTION
with the following code:
```cpp
template <typename T>
static inline T get_single_param_(const char *param_name, T default_value)
{
    std::array<T, 1> buf;
    if (nh.getParam(param_name, buf.data())) {
        return buf[0];
    } else {
        return default_value;
    }
}
```
Under rp2040 (arm-none-eabi-gcc, 32bit), if T is "int", gcc will convert
the int to "short int" thus failing compilation.
Using "int32_t" for T didn't help, and fundamentally it's a problem of
"int" not being really cross-platform.
Changing the "int" in rosserial_client.h to "int32_t" fixed the issue.

Ultimately, all "int" in the codebase should be "int32_t" including
message_generation, but that would be a breaking change.

Even this change might be breaking for some codes.