### PR TITLE
[rosserial_python] Use rospy.on_shutdown in SerialClient shutdown

### DIFF
--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -397,7 +397,11 @@ class SerialClient(object):
         self.requestTopics()
         self.lastsync = rospy.Time.now()
 
-        signal.signal(signal.SIGINT, self.txStopRequest)
+        def shutdown():
+            self.txStopRequest()
+            rospy.loginfo('shutdown hook activated')
+        rospy.on_shutdown(shutdown)
+
 
     def requestTopics(self):
         """ Determine topics to subscribe/publish. """
@@ -411,7 +415,7 @@ class SerialClient(object):
         # request topic sync
         self.write_queue.put("\xff" + self.protocol_ver + "\x00\x00\xff\x00\x00\xff")
 
-    def txStopRequest(self, signal, frame):
+    def txStopRequest(self):
         """ send stop tx request to arduino when receive SIGINT(Ctrl-c)"""
         if not self.fix_pyserial_for_test:
             with self.read_lock:
@@ -421,7 +425,6 @@ class SerialClient(object):
 
         # tx_stop_request is x0b
         rospy.loginfo("Send tx stop request")
-        sys.exit(0)
 
     def tryRead(self, length):
         try:


### PR DESCRIPTION
When I use `serial_node.py` from roslaunch, we cannot kill `serial_node.py` by Ctrl-c.

This is because `serial_node.py` does not catch `SystemExit` exception caused by `sys.exit(0)` in `txStopRequest`.
https://github.com/ros-drivers/rosserial/blob/c169ae2173dcfda7cee567d64beae45198459400/rosserial_python/nodes/serial_node.py#L94-L109

In this PR, I used `rospy.on_shutdown` instead of `signal.signal(signal.SIGINT, self.txStopRequest)`, following [`8fb7954` (#508)](https://github.com/ros-drivers/rosserial/pull/508/commits/8fb795456b5ed39aed1d256f757558b5848cebfa) and https://github.com/ros-drivers/rosserial/pull/551
This change enables to kill `serial_node.py` by Ctrl-c.

Thank you very much for your help, @sktometometo