### PR TITLE
[rosserial_python] Stop old thread before recreating new SerialClient

### DIFF
--- a/rosserial_python/nodes/serial_node.py
+++ b/rosserial_python/nodes/serial_node.py
@@ -105,5 +105,6 @@ if __name__=="__main__":
             except:
                 rospy.logwarn("Unexpected Error: %s", sys.exc_info()[0])
                 client.port.close()
+                client.stopWriteThread()
                 sleep(1.0)
                 continue


### PR DESCRIPTION
In `serial_node.py`, when an `"Unexpected Error"` occurs, the `client` variable is recreated.
However, the `write_thread` thread used in the `client` variable is not released at that time.
This will increase the number of threads as "Unexpected Error" is repeated.

I checked the number of thread in `serial_node.py` with the following command.
```
import threading
threading.active_count()
```

If the number of threads exceeds the `ulimit -u` limit, no other processes can be launched.
For your reference, I share the error logs I am getting with my robot.
```
OpenBLAS blas_thread_init: pthread_create failed for thread 10 of 12: Resource temporarily unavailable
OpenBLAS blas_thread_init: RLIMIT_NPROC 126864 current, 126864 max
```
```
thread.error: can't start new thread
```
https://gist.github.com/708yamaguchi/ff32e5921570e7e004836a758665acde