### PR TITLE
[Melodic backport of #595] [rosserial_python] Stop old thread before recreating new SerialClient

### DIFF
--- a/rosserial_python/nodes/serial_node.py
+++ b/rosserial_python/nodes/serial_node.py
@@ -98,6 +98,7 @@ if __name__=="__main__":
             except:
                 rospy.logwarn("Unexpected Error.%s", sys.exc_info()[0])
                 client.port.close()
+                client.stopWriteThread()
                 sleep(1.0)
                 continue
 

--- a/rosserial_python/src/rosserial_python/SerialClient.py
+++ b/rosserial_python/src/rosserial_python/SerialClient.py
@@ -328,6 +328,7 @@ class SerialClient(object):
 
         self.write_lock = threading.RLock()
         self.write_queue = Queue()
+        self.write_alive = False
         self.write_thread = None
 
         self.lastsync = rospy.Time(0)
@@ -448,6 +449,7 @@ class SerialClient(object):
 
         # Launch write thread.
         if self.write_thread is None:
+            self.write_alive = True
             self.write_thread = threading.Thread(target=self.processWriteQueue)
             self.write_thread.daemon = True
             self.write_thread.start()
@@ -555,6 +557,11 @@ class SerialClient(object):
                 with self.write_lock:
                     self.port.flushOutput()
                 self.requestTopics()
+
+    def stopWriteThread(self):
+        # stop self.write_thread
+        self.write_alive = False
+        self.write_thread.join()
 
     def setPublishSize(self, bytes):
         if self.buffer_out < 0:
@@ -771,7 +778,7 @@ class SerialClient(object):
         """
         Main loop for the thread that processes outgoing data to write to the serial port.
         """
-        while not rospy.is_shutdown():
+        while not rospy.is_shutdown() and self.write_alive:
             if self.write_queue.empty():
                 time.sleep(0.01)
             else:


### PR DESCRIPTION
Melodic backport of #595
