### PR TITLE
Import setup from setuptools instead of distutils.core

### DIFF
--- a/rosserial/package.xml
+++ b/rosserial/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rosserial</name>
   <version>0.9.2</version>
   <description>
@@ -12,9 +12,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>rosserial_msgs</run_depend>
-  <run_depend>rosserial_client</run_depend>
-  <run_depend>rosserial_python</run_depend>
+  <exec_depend>rosserial_msgs</exec_depend>
+  <exec_depend>rosserial_client</exec_depend>
+  <exec_depend>rosserial_python</exec_depend>
 
   <export>
    <metapackage/>

--- a/rosserial_arduino/package.xml
+++ b/rosserial_arduino/package.xml
@@ -12,6 +12,8 @@
   <url>http://ros.org/wiki/rosserial_arduino</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>message_generation</build_depend>
 

--- a/rosserial_arduino/package.xml
+++ b/rosserial_arduino/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rosserial_arduino</name>
   <version>0.9.2</version>
   <description>
@@ -15,10 +15,10 @@
 
   <build_depend>message_generation</build_depend>
 
-  <run_depend>arduino-core</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>rosserial_msgs</run_depend>
-  <run_depend>rosserial_client</run_depend>
-  <run_depend>message_runtime</run_depend>
-  <run_depend>rosserial_python</run_depend>
+  <exec_depend>arduino-core</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>rosserial_msgs</exec_depend>
+  <exec_depend>rosserial_client</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>rosserial_python</exec_depend>
 </package>

--- a/rosserial_arduino/setup.py
+++ b/rosserial_arduino/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/rosserial_chibios/package.xml
+++ b/rosserial_chibios/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rosserial_chibios</name>
   <version>0.9.2</version>
   <description>
@@ -11,5 +11,5 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>rosserial_client</run_depend>
+  <exec_depend>rosserial_client</exec_depend>
 </package>

--- a/rosserial_client/package.xml
+++ b/rosserial_client/package.xml
@@ -1,4 +1,4 @@
-<package format="2">
+<package format="3">
   <name>rosserial_client</name>
   <version>0.9.2</version>
   <description>

--- a/rosserial_client/package.xml
+++ b/rosserial_client/package.xml
@@ -12,6 +12,8 @@
   <url>http://ros.org/wiki/rosserial_client</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
   <build_export_depend>rosbash</build_export_depend>
 
   <exec_depend>rosserial_msgs</exec_depend>

--- a/rosserial_client/setup.py
+++ b/rosserial_client/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/rosserial_embeddedlinux/package.xml
+++ b/rosserial_embeddedlinux/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rosserial_embeddedlinux</name>
   <version>0.9.2</version>
   <description>
@@ -14,6 +14,6 @@
 
   <build_depend>rosserial_client</build_depend>
 
-  <run_depend>rospy</run_depend>
-  <run_depend>rosserial_msgs</run_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>rosserial_msgs</exec_depend>
 </package>

--- a/rosserial_mbed/package.xml
+++ b/rosserial_mbed/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rosserial_mbed</name>
   <version>0.9.2</version>
   <description>
@@ -13,10 +13,10 @@
 
   <build_depend>message_generation</build_depend>
 
-  <run_depend>rospy</run_depend>
-  <run_depend>rosserial_msgs</run_depend>
-  <run_depend>rosserial_client</run_depend>
-  <run_depend>message_runtime</run_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>rosserial_msgs</exec_depend>
+  <exec_depend>rosserial_client</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
 </package>
 
 

--- a/rosserial_msgs/package.xml
+++ b/rosserial_msgs/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rosserial_msgs</name>
   <version>0.9.2</version>
   <description>
@@ -14,5 +14,5 @@
 
   <build_depend>message_generation</build_depend>
 
-  <run_depend>message_runtime</run_depend>
+  <exec_depend>message_runtime</exec_depend>
 </package>

--- a/rosserial_python/package.xml
+++ b/rosserial_python/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rosserial_python</name>
   <version>0.9.2</version>
   <description>
@@ -12,8 +12,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>rospy</run_depend>
-  <run_depend>rosserial_msgs</run_depend>
-  <run_depend>diagnostic_msgs</run_depend>
-  <run_depend>python3-serial</run_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>rosserial_msgs</exec_depend>
+  <exec_depend>diagnostic_msgs</exec_depend>
+  <exec_depend>python3-serial</exec_depend>
 </package>

--- a/rosserial_python/package.xml
+++ b/rosserial_python/package.xml
@@ -11,6 +11,8 @@
   <url>http://ros.org/wiki/rosserial_python</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <exec_depend>rospy</exec_depend>
   <exec_depend>rosserial_msgs</exec_depend>

--- a/rosserial_python/setup.py
+++ b/rosserial_python/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/rosserial_server/package.xml
+++ b/rosserial_server/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>rosserial_server</name>
   <version>0.9.2</version>
   <description>

--- a/rosserial_test/package.xml
+++ b/rosserial_test/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>rosserial_test</name>
   <version>0.9.2</version>
   <description>

--- a/rosserial_tivac/package.xml
+++ b/rosserial_tivac/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rosserial_tivac</name>
   <version>0.9.2</version>
   <description>
@@ -13,8 +13,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>rosserial_msgs</run_depend>
-  <run_depend>rosserial_client</run_depend>
+  <exec_depend>rosserial_msgs</exec_depend>
+  <exec_depend>rosserial_client</exec_depend>
 </package>
 
 

--- a/rosserial_vex_cortex/package.xml
+++ b/rosserial_vex_cortex/package.xml
@@ -10,6 +10,8 @@
   <!--<url>http://ros.org/wiki/rosserial_arduino</url>-->
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <exec_depend>rospy</exec_depend>
   <exec_depend>rosserial_client</exec_depend>

--- a/rosserial_vex_cortex/package.xml
+++ b/rosserial_vex_cortex/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rosserial_vex_cortex</name>
   <version>0.9.2</version>
   <description>
@@ -11,7 +11,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>rospy</run_depend>
-  <run_depend>rosserial_client</run_depend>
-  <run_depend>rosserial_python</run_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>rosserial_client</exec_depend>
+  <exec_depend>rosserial_python</exec_depend>
 </package>

--- a/rosserial_vex_cortex/setup.py
+++ b/rosserial_vex_cortex/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/rosserial_vex_v5/package.xml
+++ b/rosserial_vex_v5/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rosserial_vex_v5</name>
   <version>0.9.2</version>
   <description>
@@ -11,7 +11,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>rospy</run_depend>
-  <run_depend>rosserial_client</run_depend>
-  <run_depend>rosserial_python</run_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>rosserial_client</exec_depend>
+  <exec_depend>rosserial_python</exec_depend>
 </package>

--- a/rosserial_vex_v5/package.xml
+++ b/rosserial_vex_v5/package.xml
@@ -10,6 +10,8 @@
   <!--<url>http://ros.org/wiki/rosserial_arduino</url>-->
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <exec_depend>rospy</exec_depend>
   <exec_depend>rosserial_client</exec_depend>

--- a/rosserial_vex_v5/setup.py
+++ b/rosserial_vex_v5/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(

--- a/rosserial_windows/package.xml
+++ b/rosserial_windows/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rosserial_windows</name>
   <version>0.9.2</version>
   <description>
@@ -17,10 +17,10 @@
   <build_depend>nav_msgs</build_depend>
   <build_depend>rosserial_client</build_depend>
 
-  <run_depend>rospy</run_depend>
-  <run_depend>rosserial_msgs</run_depend>
-  <run_depend>rosserial_client</run_depend>
-  <run_depend>message_runtime</run_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>rosserial_msgs</exec_depend>
+  <exec_depend>rosserial_client</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
 </package>
 
 

--- a/rosserial_xbee/package.xml
+++ b/rosserial_xbee/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="3">
   <name>rosserial_xbee</name>
   <version>0.9.2</version>
   <description>
@@ -18,10 +18,10 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>rospy</run_depend>
-  <run_depend>rosserial_msgs</run_depend>
-  <run_depend>diagnostic_msgs</run_depend>
-  <run_depend>python3-serial</run_depend>
-  <run_depend>rosserial_python</run_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>rosserial_msgs</exec_depend>
+  <exec_depend>diagnostic_msgs</exec_depend>
+  <exec_depend>python3-serial</exec_depend>
+  <exec_depend>rosserial_python</exec_depend>
 </package>
 

--- a/rosserial_xbee/package.xml
+++ b/rosserial_xbee/package.xml
@@ -17,6 +17,8 @@
   <url>http://ros.org/wiki/rosserial_xbee</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <exec_depend>rospy</exec_depend>
   <exec_depend>rosserial_msgs</exec_depend>

--- a/rosserial_xbee/setup.py
+++ b/rosserial_xbee/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
Recently users of newer distributions who build Noetic from source noticed issues when importing setup from distutils.core.
This problem was discussed on [Discourse](https://discourse.ros.org/t/ros-1-and-python-3-10s-deprecation-of-distutils-core/29834), and we hope that we can make the needed updates to Noetic to allow for future builds from source of Noetic.
As a first step, this PR introduces changes from the [Noetic Migration Guide](https://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils) that addresses the change to the setuptools module instead of distutils.core and the corresponding buildtool_depend tags for python 2&3.