### PR TITLE
Adding support for microcontrollers such as ESP32-S2/-S3/-C3

### DIFF
--- a/rosserial_arduino/src/ros_lib/ArduinoHardware.h
+++ b/rosserial_arduino/src/ros_lib/ArduinoHardware.h
@@ -59,7 +59,15 @@
   #define SERIAL_CLASS USBSerial
 #else 
   #include <HardwareSerial.h>  // Arduino AVR
-  #define SERIAL_CLASS HardwareSerial
+  #if defined(USE_USBCDC)
+    // ESP32-S2 ESP32-C3
+    #define SERIAL_CLASS USBCDC
+  #elif defined(USE_HWCDC)
+    // ESP32-S3
+    #define SERIAL_CLASS HWCDC
+  #else
+    #define SERIAL_CLASS HardwareSerial
+  #endif
 #endif
 
 class ArduinoHardware {


### PR DESCRIPTION
Adding support for microcontrollers that do not have a dedicated USB-to-UART chip, such as the ESP32-S2, ESP32-S3, and ESP32-C3.