### PR TITLE
rosserial_server: Fix access to uninitialized memory in handling service calls

### DIFF
--- a/rosserial_server/include/rosserial_server/topic_handlers.h
+++ b/rosserial_server/include/rosserial_server/topic_handlers.h
@@ -165,9 +165,8 @@ public:
     ros::serialization::Serializer<topic_tools::ShapeShifter>::read(stream, request_message_);
 
     // perform service call
-    // note that at present, at least for rosserial-windows a service call returns nothing,
-    // so we discard the return value of this call() invocation.
-    service_client_.call(request_message_, response_message_, service_md5_);
+    if (!service_client_.call(request_message_, response_message_, service_md5_))
+      return;
 
     // write service response over the wire
     size_t length = ros::serialization::serializationLength(response_message_);


### PR DESCRIPTION
When handling a service call, the C++ server doesn't check that the service is available, and it also doesn't check whether the service succeeded. If the service fails, the caller should assume it has not touched the reference to the response object. But the response object passed here is an uninitialized ShapeShifter. Therefore, without this fix, the uninitialized ShapeShifter is published as the service response, which is super bad!

There was an unclear note about `.call()` not returning anything on windows. On Windows? Since when do the rosserial servers run on windows? I hope this was some mistake and actually checking the return value of `.call()` will not break anything that should work.