### PR TITLE
[rosserial_client] fix deserialization for nested array

### DIFF
--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -249,14 +249,34 @@ class ArrayDataType(PrimitiveDataType):
             f.write('      %s_lengthT |= ((uint32_t) (*(inbuffer + offset + 2))) << (8 * 2); \n' % self.name)
             f.write('      %s_lengthT |= ((uint32_t) (*(inbuffer + offset + 3))) << (8 * 3); \n' % self.name)
             f.write('      offset += sizeof(this->%s_length);\n' % self.name)
-            f.write('      if(%s_lengthT > %s_length)\n' % (self.name, self.name))
+            f.write('      if(%s_lengthT > %s_length){\n' % (self.name, self.name))
             f.write('        this->%s = (%s*)realloc(this->%s, %s_lengthT * sizeof(%s));\n' % (self.name, self.type, self.name, self.name, self.type))
-            f.write('      %s_length = %s_lengthT;\n' % (self.name, self.name))
-            # copy to array
-            f.write('      for( uint32_t i = 0; i < %s_length; i++){\n' % (self.name) )
-            c.deserialize(f)
-            f.write('        memcpy( &(this->%s[i]), &(this->st_%s), sizeof(%s));\n' % (self.name, self.name, self.type))
+
+            if self.cls is MessageDataType:
+                # array of message. Initialize new slot as 0 and directly deserialize
+                f.write('        for (uint32_t i = %s_length; i < %s_lengthT; ++i) {\n' % (self.name, self.name))
+                f.write('          %s zero{};\n' % (self.type))
+                f.write('          memcpy(&(this->%s[i]), &zero, sizeof(%s));\n' % (self.name, self.type))
+                f.write('        }\n')
+            else:
+                # primitive
+                f.write('        ;\n')
+
             f.write('      }\n')
+            f.write('      %s_length = %s_lengthT;\n' % (self.name, self.name))
+
+            if self.cls is MessageDataType:
+                # array of message. directory deserializ
+                f.write('      for (uint32_t i = 0; i < %s_length; ++i) {\n' % (self.name))
+                f.write('        offset += this->%s[i].deserialize(inbuffer + offset);\n' % self.name)
+                f.write('      }\n')
+            else:
+                # primitive
+                f.write('      for (uint32_t i = 0; i < %s_length; ++i) {\n' % (self.name))
+                c.deserialize(f)  # use st_<name>
+                f.write('        memcpy(&(this->%s[i]), &(this->st_%s), sizeof(%s));\n'
+                        % (self.name, self.name, self.type))
+                f.write('      }\n')
         else:
             c = self.cls(self.name+"[i]", self.type, self.bytes)
             f.write('      for( uint32_t i = 0; i < %d; i++){\n' % (self.size) )

--- a/rosserial_client/src/rosserial_client/make_library.py
+++ b/rosserial_client/src/rosserial_client/make_library.py
@@ -258,9 +258,6 @@ class ArrayDataType(PrimitiveDataType):
                 f.write('          %s zero{};\n' % (self.type))
                 f.write('          memcpy(&(this->%s[i]), &zero, sizeof(%s));\n' % (self.name, self.type))
                 f.write('        }\n')
-            else:
-                # primitive
-                f.write('        ;\n')
 
             f.write('      }\n')
             f.write('      %s_length = %s_lengthT;\n' % (self.name, self.name))


### PR DESCRIPTION
This patch enables to receive array of array in microcontroller correctly by fixing deserialization fofr message.

When sending an array of arrays to the microcontroller, accessing it yielded the same value even though it should have sent different values.
This is caused by a deserialization error resulting in the same pointer being referenced.
A similar report can be found at https://github.com/ros-drivers/rosserial/issues/314#issuecomment-1078665866.

I fixed the part that deserializes messages. I deserialized each element composing the array directly to prevent sharing pointers.